### PR TITLE
Make left calculation culture invariant

### DIFF
--- a/Heron.MudCalendar/Base/DayWeekViewBase.razor.cs
+++ b/Heron.MudCalendar/Base/DayWeekViewBase.razor.cs
@@ -44,7 +44,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IAsyncDisposab
             .AddStyle("top", $"{CalcTop(position.Item)}px")
             .AddStyle("height", $"{CalcHeight(position.Item)}px")
             .AddStyle("overflow", "hidden")
-            .AddStyle("left", ((position.Position / (double)position.Total) - (1.0 / position.Total)) * 100 + "%")
+            .AddStyle("left", (((position.Position / (double)position.Total) - (1.0 / position.Total)) * 100).ToInvariantString() + "%")
             .AddStyle("width", (100 / position.Total) + "%" )
             .Build();
     }


### PR DESCRIPTION
When multiple events occur simultaneously, the calculation to arrange them side by side fails to work correctly if your machine's culture uses decimal separators, such as in the case of the Netherlands (NL).

Example:
![image](https://github.com/danheron/Heron.MudCalendar/assets/51820925/5709f4be-b6f5-4a3f-869f-382bdfd52d82)

When the entire app is set to use the InvariantCulture or a culture that doesn't utilize decimal separators, the calculation functions properly. However, this approach is not ideal as there are certain aspects that should be optimized based on the client's culture.

In this PR I've changed the calculation to ensure that the ToString is invariant. This way it maintains consistency in decimal formatting.
