### PR TITLE
Fix wrong DateRangeText

### DIFF
--- a/Heron.MudCalendar/Components/CalendarDatePicker.razor.cs
+++ b/Heron.MudCalendar/Components/CalendarDatePicker.razor.cs
@@ -22,7 +22,7 @@ public partial class CalendarDatePicker
                     var range = new CalendarDateRange(Date.Value, View);
                     return range.End != null && range.Start != null && range.Start.Value.Month == range.End.Value.Month ? 
                         $"{range.Start:dd} - {range.End:dd} {range.End.Value:MMM yyyy}" : 
-                        $"{range.Start:dd} {range.End:MMM} - {range.End:dd} {range.End?.ToString("MMM yyyy")}";
+                        $"{range.Start:dd} {range.Start:MMM} - {range.End:dd} {range.End?.ToString("MMM yyyy")}";
                 
                 case CalendarView.Month:
                 default:


### PR DESCRIPTION
The month for the starting date was the month of the end. This means that if the date is from August 27th to September 2nd, it would be displayed as 27 **SEP** – 02 SEP. 