### PR TITLE
Fix toolbar item alignment

### DIFF
--- a/Heron.MudCalendar/Components/MudCalendar.razor
+++ b/Heron.MudCalendar/Components/MudCalendar.razor
@@ -58,7 +58,7 @@
     /// </summary>
     protected virtual RenderFragment RenderToolbar =>
         @<div class="mud-cal-toolbar pa-4">
-            <div class="d-flex">
+            <div class="d-flex align-center">
                 @if (ShowPrevNextButtons)
                 {
                     <MudIconButton Variant="@ButtonVariant" Icon="@Icons.Material.Outlined.ChevronLeft" Color="@Color" OnClick="OnPreviousClicked" Class="mx-1"/>


### PR DESCRIPTION
When using Variant.Text for the ButtonVariant property the toolbar items would have different alignment.

**Before:**
![image](https://github.com/user-attachments/assets/70ebf235-ac33-4695-be3b-a89d7be04469)
**After:**
![image](https://github.com/user-attachments/assets/547b4054-a860-4599-9c68-04721baeec0c)