### PR TITLE
Added CalendarTimeInterval.Minutes5

### DIFF
--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/TimeIntervalCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/TimeIntervalCalendarExample.razor
@@ -5,6 +5,7 @@
 <MudToolBar Class="mt-4">
     <MudSwitch @bind-Value="_showCurrentTime" T="bool" Color="Color.Primary" Label="Show Current Time" />
     <MudSelect @bind-Value="_interval" T="CalendarTimeInterval" Label="Time Interval" class="ml-4">
+        <MudSelectItem Value="CalendarTimeInterval.Minutes5">5 Minutes</MudSelectItem>
         <MudSelectItem Value="CalendarTimeInterval.Minutes10">10 Minutes</MudSelectItem>
         <MudSelectItem Value="CalendarTimeInterval.Minutes15">15 Minutes</MudSelectItem>
         <MudSelectItem Value="CalendarTimeInterval.Minutes20">20 Minutes</MudSelectItem>

--- a/Heron.MudCalendar/Enums/CalendarTimeInterval.cs
+++ b/Heron.MudCalendar/Enums/CalendarTimeInterval.cs
@@ -2,6 +2,7 @@ namespace Heron.MudCalendar;
 
 public enum CalendarTimeInterval
 {
+    Minutes5 = 5,
     Minutes10 = 10,
     Minutes15 = 15,
     Minutes20 = 20,


### PR DESCRIPTION
First of all, thanks for this awesome component! It is already very useful for my small personal project.
In my use case it would be very helpful to quickly edit the calendar items via drag & drop. The smallest timeframe needed is 5 minutes. Currently the smallest is 10. I added a 5 Minutes option to the CalendarTimeInterval enum.

I was able to successfully run all unit tests as well as the unit tests viewer:
![image](https://github.com/user-attachments/assets/d0c8ddbd-80e0-4e2b-a80f-7627929ac141)

However, I was not able to test the Docs, even after cloning the MudBlazor/mudcalendar repo into the same parent folder and building it in release. I got:
```
blazor.webassembly.js:1 crit: Microsoft.AspNetCore.Components.WebAssembly.Rendering.WebAssemblyRenderer[100]
      Unhandled exception rendering component: Object of type 'MudBlazor.Docs.Components.SectionContent' does not have a property matching the name 'Assembly'.
System.InvalidOperationException: Object of type 'MudBlazor.Docs.Components.SectionContent' does not have a property matching the name 'Assembly'.
   at Microsoft.AspNetCore.Components.Reflection.ComponentProperties.ThrowForUnknownIncomingParameterName(Type targetType, String parameterName)
   at Microsoft.AspNetCore.Components.Reflection.ComponentProperties.SetProperties(ParameterView& parameters, Object target)
   at Microsoft.AspNetCore.Components.ParameterView.SetParameterProperties(Object target)
   at Microsoft.AspNetCore.Components.ComponentBase.SetParametersAsync(ParameterView parameters)
   at Microsoft.AspNetCore.Components.Rendering.ComponentState.SupplyCombinedParameters(ParameterView directAndCascadingParameters)
Dt @ blazor.webassembly.js:1
carbon.js:1 
        
        
       Failed to load resource: net::ERR_BLOCKED_BY_CLIENT
```