### PR TITLE
Update user experience when in month view

### DIFF
--- a/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
+++ b/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
@@ -237,7 +237,8 @@ public class CalendarTests : BunitTest
     {
         var cut = Context.RenderComponent<CalendarTest>();
         var comp = cut.FindComponent<MudCalendar>();
-        
+
+        comp.SetParam(x => x.View, CalendarView.Week);
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 2, 1));
         comp.FindAll("div.mud-cal-toolbar button")[0].Click();
 

--- a/Heron.MudCalendar/Components/MudCalendar.razor
+++ b/Heron.MudCalendar/Components/MudCalendar.razor
@@ -66,7 +66,7 @@
                 }
                 @if (ShowDatePicker)
                 {
-                    <CalendarDatePicker @ref="_datePicker" Date="PickerDate" DateChanged="DatePickerDateChanged" View="View" Variant="ButtonVariant" Color="Color" Class="mx-1" PickerOpened="OnDatePickerOpened"/>
+                    <CalendarDatePicker @ref="_datePicker" OpenTo="@(View == CalendarView.Month ? OpenTo.Month : OpenTo.Date)" FixDay="@(View == CalendarView.Month ? PickerDate.Value.Day : null)" Date="PickerDate" DateChanged="DatePickerDateChanged" View="View" Variant="ButtonVariant" Color="Color" Class="mx-1" PickerOpened="OnDatePickerOpened"/>
                 }
                 @if (ShowTodayButton)
                 {


### PR DESCRIPTION
Closes #155 

When in month view now the underlying datepicker will open to the month picker and set the day to the currently selected day, this eliminates the user having to select a day after they pick a month (which isn't necessary because they are in month view).

I also had to fix a test as this change affected the text that the test was looking for ("January 2023" vs "2023" when in month picker mode). 

For the default values for OpenTo and FixDay I followed the source from Mudblazor: 
- https://github.com/MudBlazor/MudBlazor/blob/04c2ece527ed5e85e654ca7e955cf88314a18ca1/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs#L278-L286
- https://github.com/MudBlazor/MudBlazor/blob/04c2ece527ed5e85e654ca7e955cf88314a18ca1/src/MudBlazor/Components/DatePicker/MudBaseDatePicker.razor.cs#L47-L55

All tests passed, and visually tested with unit test viewer project.

**Before:**
![monthviewbefore](https://github.com/user-attachments/assets/3b964723-7f58-41fb-b956-d32da63bb247)

**After:**
![monthviewupdate](https://github.com/user-attachments/assets/0ac94680-c020-45e4-b937-1b10ce89a567)
