### PR TITLE
Add styling example

### DIFF
--- a/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMonthViewStylingExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMonthViewStylingExample.razor
@@ -1,0 +1,63 @@
+@using Heron.MudCalendar
+@using MudBlazor.Extensions
+@using MudBlazor.Utilities
+@inherits MonthView
+
+@Render
+
+@code {
+
+  protected override string DayStyle(CalendarCell calendarCell, int index)
+  {
+    return new StyleBuilder()
+    .AddStyle("border-right", "none",
+    (index + 1) % Columns == 0 && !(calendarCell.Today && Calendar.HighlightToday))
+    .AddStyle("border", $"1px solid var(--mud-palette-{Calendar.Color.ToDescriptionString()})",
+    calendarCell.Today && Calendar.HighlightToday)
+    .AddStyle("width", $"{(100.0 / Columns).ToInvariantString()}%")
+    // If weekend color cells with --mud-palette-background-gray
+    .AddStyle("background-color", "var(--mud-palette-background-gray)", calendarCell.Date.DayOfWeek == DayOfWeek.Sunday || calendarCell.Date.DayOfWeek == DayOfWeek.Saturday)
+    // If day is outside of current month, color cells with --mud-palette-skeleton
+    .AddStyle("background-color", "var(--mud-palette-skeleton)", calendarCell.Outside)
+    .Build();
+  }
+
+  protected override RenderFragment RenderCellDayNumber(CalendarCell cell) =>
+  @<MudStack Class="py-0 px-1 ma-0" Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
+    @if(!cell.Outside) {
+      // Make Wednesdays red
+      if(cell.Date.DayOfWeek == DayOfWeek.Wednesday){
+        <MudText Typo="Typo.body2" Color="Color.Error"><b>@cell.Date.Day</b> <i>@(cell.Today ? "(Today)" : string.Empty)</i></MudText>
+      } else {
+        // Regular day and today styling
+        <MudText Typo="Typo.body2"><b>@cell.Date.Day</b> <i>@(cell.Today ? "(Today)" : string.Empty)</i></MudText>
+      }
+    } else {
+      int daysInMonth = DateTime.DaysInMonth(cell.Date.Year, cell.Date.Month);
+
+      if(cell.Date.Day == daysInMonth){
+        // Style last day of of previous month
+        <MudStack Style="width:100%" Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+          <MudText Typo="Typo.caption" Style="font-weight:300;font-style:italic">@cell.Date.Day</MudText>
+          <MudText Typo="Typo.caption" Style="font-weight:300;font-style:italic">@($"< {cell.Date.ToString("MMMM")}")</MudText>
+        </MudStack>
+      }
+      else if(cell.Date.Day == 1){
+        // Style first day of next month
+        <MudStack Style="width:100%" Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+          <MudText Typo="Typo.caption" Style="font-weight:300;font-style:italic">@($"{cell.Date.ToString("MMMM")} >")</MudText>
+          <MudText Typo="Typo.caption" Style="font-weight:300;font-style:italic">@cell.Date.Day</MudText>
+        </MudStack>
+      } else if(cell.Date.Day > 1 && cell.Date.Day < 7){
+        // Style days in next month
+        <MudStack Style="width:100%" Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+          <MudSpacer />
+          <MudText Typo="Typo.caption" Style="font-weight:300;font-style:italic">@cell.Date.Day (Future)</MudText>
+        </MudStack>
+      } else{
+        // Style days in previous month
+        <MudText Typo="Typo.caption" Style="font-weight:300;font-style:italic">@cell.Date.Day (Past)</MudText>
+      }
+  }
+  </MudStack>;
+}

--- a/Heron.MudCalendar.Docs/Pages/Extending/Extending.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/Extending.razor
@@ -1,60 +1,75 @@
 @page "/extending"
+@using Heron.MudCalendar.Docs.Pages.Extending.Examples
 
 <DocsPage>
-    <DocsPageHeader Title="Extending" SubTitle="Extending MudCalendar"/>
-    <DocsPageContent>
+  <DocsPageHeader Title="Extending" SubTitle="Extending MudCalendar" />
+  <DocsPageContent>
+
+    <DocsPageSection>
+      <SectionHeader Title="Creating a Custom Calendar Component">
+        <Description>
+          The <CodeInline>MudCalendar</CodeInline> component can be extended by inheriting and overriding the methods that render the component.<br />
+          This example shows how to create a custom calendar component that renders the month day numbers as MudAvatar components.
+        </Description>
+      </SectionHeader>
+      <SectionSubGroups>
 
         <DocsPageSection>
-            <SectionHeader Title="Creating a Custom Calendar Component">
-                <Description>
-                    The <CodeInline>MudCalendar</CodeInline> component can be extended by inheriting and overriding the methods that render the component.<br />
-                    This example shows how to create a custom calendar component that renders the month day numbers as MudAvatar components.
-                </Description>
-            </SectionHeader>
+          <SectionHeader Title="Create a subclass of the MonthView component">
+            <Description>
+              Create a <CodeInline>CustomMonthView</CodeInline> component that inherits from <CodeInline>MonthView</CodeInline> and override the method that renders the day numbers.
+            </Description>
+          </SectionHeader>
+          <SectionContent DarkenBackground="true" Code="CustomMonthViewExample" ShowCode="true" Block="true" FullWidth="true" Assembly="typeof(Extending).Assembly" AllowRunCode="false">
+          </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Create a subclass of the MonthView component">
-                <Description>
-                    Create a <CodeInline>CustomMonthView</CodeInline> component that inherits from <CodeInline>MonthView</CodeInline> and override the method that renders the day numbers.
-                </Description>
-            </SectionHeader>
-            <SectionContent DarkenBackground="true" Code="CustomMonthViewExample" ShowCode="true" Block="true" FullWidth="true" Assembly="typeof(Extending).Assembly" AllowRunCode="false">
-            </SectionContent>
+          <SectionHeader Title="Create a subclass of the MudCalendar component">
+            <Description>
+              Then create a <CodeInline>CustomCalendar</CodeInline> component that inherits from <CodeInline>MudCalendar</CodeInline> and override the method that displays
+              the <CodeInline>MonthView</CodeInline> to use the new <CodeInline>CustomMonthView</CodeInline> component.
+            </Description>
+          </SectionHeader>
+          <SectionContent DarkenBackground="true" Code="CustomMudCalendarExample" ShowCode="true" Block="true" FullWidth="true" Assembly="typeof(Extending).Assembly" AllowRunCode="false">
+          </SectionContent>
         </DocsPageSection>
 
         <DocsPageSection>
-            <SectionHeader Title="Create a subclass of the MudCalendar component">
-                <Description>
-                    Then create a <CodeInline>CustomCalendar</CodeInline> component that inherits from <CodeInline>MudCalendar</CodeInline> and override the method that displays
-                    the <CodeInline>MonthView</CodeInline> to use the new <CodeInline>CustomMonthView</CodeInline> component.
-                </Description>
-            </SectionHeader>
-            <SectionContent DarkenBackground="true" Code="CustomMudCalendarExample" ShowCode="true" Block="true" FullWidth="true" Assembly="typeof(Extending).Assembly" AllowRunCode="false">
-            </SectionContent>
+          <SectionHeader Title="Result">
+            <Description>
+              The <CodeInline>CustomCalendar</CodeInline> component looks like this.
+            </Description>
+          </SectionHeader>
+          <SectionContent>
+            <CustomCalendar />
+          </SectionContent>
         </DocsPageSection>
 
-        <DocsPageSection>
-            <SectionHeader Title="Result">
-                <Description>
-                    The <CodeInline>CustomCalendar</CodeInline> component looks like this.
-                </Description>
-            </SectionHeader>
-            <SectionContent>
-                <CustomCalendar/>
-            </SectionContent>
-        </DocsPageSection>
-        
-        @* <DocsPageSection> *@
-        @*     <SectionHeader Title="Heron.MudTotalCalendar"> *@
-        @*         <Description><CodeInline>Heron.MudTotalCalendar</CodeInline> is a calendar component for displaying numeric values and totals.   *@
-        @*             It can be used as an example of extending <CodeInline>Heron.MudCalendar</CodeInline>.   *@
-        @*             The source code can be found on <MudLink Href="https://github.com/danheron/Heron.MudTotalCalendar">Github</MudLink>.</Description> *@
-        @*     </SectionHeader> *@
-        @*     <SectionContent> *@
-        @*         <TotalCalendar /> *@
-        @*     </SectionContent> *@
-        @* </DocsPageSection> *@
+      </SectionSubGroups>
+    </DocsPageSection>
 
-    </DocsPageContent>
+    <DocsPageSection>
+      <SectionHeader Title="Styling Example">
+        <Description>
+          Here is an example of styling the month view's day numbers and cells for various scenarios. Weekends are light gray, outside days are darker gray with italic day number plus text, Wednesdays day numbers are red. You will need to follow the steps above to create a custom calendar component. A possible modification could be adding styling for holidays for example.
+        </Description>
+      </SectionHeader>
+      <SectionContent DarkenBackground="true" Code="CustomMonthViewStylingExample" ShowCode="false" Block="true" FullWidth="true" Assembly="typeof(Extending).Assembly" AllowRunCode="false">
+        <StyledCalendar ShowDay="false" ShowWeek="false" />
+      </SectionContent>
+    </DocsPageSection>
+
+    @* <DocsPageSection> *@
+    @*     <SectionHeader Title="Heron.MudTotalCalendar"> *@
+    @*         <Description><CodeInline>Heron.MudTotalCalendar</CodeInline> is a calendar component for displaying numeric values and totals.   *@
+    @*             It can be used as an example of extending <CodeInline>Heron.MudCalendar</CodeInline>.   *@
+    @*             The source code can be found on <MudLink Href="https://github.com/danheron/Heron.MudTotalCalendar">Github</MudLink>.</Description> *@
+    @*     </SectionHeader> *@
+    @*     <SectionContent> *@
+    @*         <TotalCalendar /> *@
+    @*     </SectionContent> *@
+    @* </DocsPageSection> *@
+
+  </DocsPageContent>
 </DocsPage>

--- a/Heron.MudCalendar.Docs/Pages/Extending/StyledCalendar.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/StyledCalendar.razor
@@ -1,0 +1,10 @@
+@inherits MudCalendar
+
+@Render
+
+@code {
+
+  protected override RenderFragment RenderMonthView =>
+        @<Heron.MudCalendar.Docs.Pages.Extending.Examples.CustomMonthViewStylingExample />;
+
+}


### PR DESCRIPTION
Added example of various styles to extending docs. Also adjusted create custom calendar component hierarchy.

![mudcalstylingexample](https://github.com/user-attachments/assets/762d8608-0860-4165-b6db-91c6ebc4c489)
