### PR TITLE
Added support for strongly typed items

### DIFF
--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/CustomCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/CustomCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" MonthCellMinHeight="120">
+<MudCalendar T="CalendarItem" Items="_events" MonthCellMinHeight="120">
     <CellTemplate>
         <div style="width: 100%; height: 100%; border: 2px solid @GetColor(((CustomItem)context).Color)">
             <div style="background-color: @GetColor(((CustomItem)context).Color)"><MudText Style="color: #ffffff;" Typo="Typo.body1" Align="Align.Center">@(((CustomItem)context).Title)</MudText></div>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/CustomCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/CustomCalendarExample.razor
@@ -1,9 +1,9 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar T="CalendarItem" Items="_events" MonthCellMinHeight="120">
+<MudCalendar T="CustomItem" Items="_events" MonthCellMinHeight="120">
     <CellTemplate>
-        <div style="width: 100%; height: 100%; border: 2px solid @GetColor(((CustomItem)context).Color)">
-            <div style="background-color: @GetColor(((CustomItem)context).Color)"><MudText Style="color: #ffffff;" Typo="Typo.body1" Align="Align.Center">@(((CustomItem)context).Title)</MudText></div>
+        <div style="width: 100%; height: 100%; border: 2px solid @GetColor(context.Color)">
+            <div style="background-color: @GetColor(context.Color)"><MudText Style="color: #ffffff;" Typo="Typo.body1" Align="Align.Center">@(context.Title)</MudText></div>
             <div class="pa-2"><MudText Typo="Typo.body2">@context.Text</MudText></div>
         </div>
     </CellTemplate>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/DragDropCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/DragDropCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" EnableDragItems="true" EnableResizeItems="true" />
+<MudCalendar T="CalendarItem" Items="_events" EnableDragItems="true" EnableResizeItems="true" />
 
 @code {
 

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/EventsCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/EventsCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" CellClicked="CellClicked" ItemClicked="ItemClicked" DayTimeInterval="CalendarTimeInterval.Minutes15" />
+<MudCalendar T="CalendarItem" Items="_events" CellClicked="CellClicked" ItemClicked="ItemClicked" DayTimeInterval="CalendarTimeInterval.Minutes15" />
 
 @code {
 

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/HeightCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/HeightCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" Height="630" MonthCellMinHeight="@(_fixed ? 0 : 115)">
+<MudCalendar T="CalendarItem" Items="_events" Height="630" MonthCellMinHeight="@(_fixed ? 0 : 115)">
     <MonthTemplate>
         <div class="d-flex gap-1">
             <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Secondary" Size="Size.Small"/>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/LoadDataCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/LoadDataCalendarExample.razor
@@ -2,7 +2,7 @@
 
 @inject EventService EventService
 
-<MudCalendar Items="_events" MonthCellMinHeight="100" DateRangeChanged="DateRangeChanged" />
+<MudCalendar T="CalendarItem" Items="_events" MonthCellMinHeight="100" DateRangeChanged="DateRangeChanged" />
 
 @code{
 

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/MobileCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/MobileCalendarExample.razor
@@ -1,7 +1,7 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
 <div style="width: 350px; margin-left: auto; margin-right: auto;">
-    <MudCalendar Items="_events" Height="600" ShowDropdownViewSelector="true" ShowPrevNextButtons="false" ToolbarPadding="4" Outlined="true">
+    <MudCalendar T="CalendarItem" Items="_events" Height="600" ShowDropdownViewSelector="true" ShowPrevNextButtons="false" ToolbarPadding="4" Outlined="true">
         <MonthTemplate>
             <div class="d-flex gap-1">
                 <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Primary" Size="Size.Small"/>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/PlaygroundCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/PlaygroundCalendarExample.razor
@@ -1,7 +1,7 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
 <MudStack Row="true" AlignItems="AlignItems.Center">
-    <MudCalendar CurrentDay="@_currentDate" Items="_events" ButtonVariant="@_buttonVariant" Elevation="@_elevation"
+    <MudCalendar T="CalendarItem" CurrentDay="@_currentDate" Items="_events" ButtonVariant="@_buttonVariant" Elevation="@_elevation"
                  Outlined="@_outlined" Color="@_color" ShowWorkWeek="@_workWeek" ShowToolbar="@_showToolbar"
                  ShowPrevNextButtons="@_prevNext" ShowDatePicker="@_datePicker" ShowTodayButton="@_todayButton"
                  MonthCellMinHeight="@(_fixedHeight ? 0 : 115)" Square="@_square" EnableDragItems="@_dragItems">

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/RestrictViewsCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/RestrictViewsCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar ShowDay="_showDay" ShowWeek="_showWeek" ShowMonth="_showMonth" ShowWorkWeek="_showWorkWeek" />
+<MudCalendar T="CalendarItem" ShowDay="_showDay" ShowWeek="_showWeek" ShowMonth="_showMonth" ShowWorkWeek="_showWorkWeek" />
 
 <MudToolBar Class="mt-4">
     <MudSwitch @bind-Value="@_showDay" Color="Color.Primary" T="bool">Show Day View</MudSwitch>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/SimpleCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/SimpleCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" />
+<MudCalendar T="CalendarItem" Items="_events" />
 
 @code {
 

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/TemplatesCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/TemplatesCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events">
+<MudCalendar T="CalendarItem" Items="_events">
     <MonthTemplate>
         <div class="d-flex gap-1">
             <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Secondary" Size="Size.Small"/>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/TimeIntervalCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/TimeIntervalCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar ShowMonth="false" DayTimeInterval="_interval" DayCellHeight="_cellHeight" ShowCurrentTime="_showCurrentTime" />
+<MudCalendar T="CalendarItem" ShowMonth="false" DayTimeInterval="_interval" DayCellHeight="_cellHeight" ShowCurrentTime="_showCurrentTime" />
 
 <MudToolBar Class="mt-4">
     <MudSwitch @bind-Value="_showCurrentTime" T="bool" Color="Color.Primary" Label="Show Current Time" />

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/ToolbarCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/ToolbarCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar>
+<MudCalendar T="CalendarItem">
     <ToolbarContent>
         <MudButton Variant="Variant.Filled" Color="Color.Secondary" Class="mx-1" OnClick="MyButtonClick">My Button</MudButton>
     </ToolbarContent>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/WeekCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/WeekCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" FirstDayOfWeek="_firstDayOfWeek" ShowMonth="false" ShowDay="false" />
+<MudCalendar T="CalendarItem" Items="_events" FirstDayOfWeek="_firstDayOfWeek" ShowMonth="false" ShowDay="false" />
 
 @code {
     private DayOfWeek _firstDayOfWeek = DayOfWeek.Tuesday;

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/WorkWeekCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/WorkWeekCalendarExample.razor
@@ -1,6 +1,6 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar Items="_events" FirstDayOfWeek="_firstDayOfWeek" FirstDayOfWorkWeek="_firstDayOfWorkWeek" ShowMonth="false" ShowDay="false" ShowWorkWeek />
+<MudCalendar T="CalendarItem" Items="_events" FirstDayOfWeek="_firstDayOfWeek" FirstDayOfWorkWeek="_firstDayOfWorkWeek" ShowMonth="false" ShowDay="false" ShowWorkWeek />
 
 @code {
     private DayOfWeek _firstDayOfWeek = DayOfWeek.Sunday;

--- a/Heron.MudCalendar.Docs/Pages/Extending/CustomCalendar.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/CustomCalendar.razor
@@ -1,4 +1,4 @@
-@inherits MudCalendar
+@inherits MudCalendar<CalendarItem>
 
 @Render
 

--- a/Heron.MudCalendar.Docs/Pages/Extending/CustomMonthView.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/CustomMonthView.razor
@@ -1,10 +1,10 @@
-@inherits MonthView
+@inherits MonthView<CalendarItem>
 
 @Render
 
 @code {
 
-    protected override RenderFragment RenderCellDayNumber(CalendarCell cell) =>
+    protected override RenderFragment RenderCellDayNumber(CalendarCell<CalendarItem> cell) =>
         @<div class="ma-2">
             <MudAvatar Color="Color.Primary">@cell.Date.Day</MudAvatar>
         </div>;

--- a/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMonthViewExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMonthViewExample.razor
@@ -1,10 +1,10 @@
-@inherits MonthView
+@inherits MonthView<CalendarItem>
 
 @Render
 
 @code {
 
-    protected override RenderFragment RenderCellDayNumber(CalendarCell cell) =>
+    protected override RenderFragment RenderCellDayNumber(CalendarCell<CalendarItem> cell) =>
         @<div class="ma-2">
             <MudAvatar Color="Color.Primary">@cell.Date.Day</MudAvatar>
         </div>;

--- a/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMonthViewStylingExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMonthViewStylingExample.razor
@@ -1,13 +1,13 @@
 @using Heron.MudCalendar
 @using MudBlazor.Extensions
 @using MudBlazor.Utilities
-@inherits MonthView
+@inherits MonthView<CalendarItem>
 
 @Render
 
 @code {
 
-  protected override string DayStyle(CalendarCell calendarCell, int index)
+    protected override string DayStyle(CalendarCell<CalendarItem> calendarCell, int index)
   {
     return new StyleBuilder()
     .AddStyle("border-right", "none",
@@ -22,7 +22,7 @@
     .Build();
   }
 
-  protected override RenderFragment RenderCellDayNumber(CalendarCell cell) =>
+    protected override RenderFragment RenderCellDayNumber(CalendarCell<CalendarItem> cell) =>
   @<MudStack Class="py-0 px-1 ma-0" Row="true" AlignItems="AlignItems.Center" Justify="Justify.SpaceBetween">
     @if(!cell.Outside) {
       // Make Wednesdays red

--- a/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMudCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/Examples/CustomMudCalendarExample.razor
@@ -1,4 +1,4 @@
-@inherits MudCalendar
+@inherits MudCalendar<CalendarItem>
 
 @Render
 

--- a/Heron.MudCalendar.Docs/Pages/Extending/StyledCalendar.razor
+++ b/Heron.MudCalendar.Docs/Pages/Extending/StyledCalendar.razor
@@ -1,4 +1,4 @@
-@inherits MudCalendar
+@inherits MudCalendar<CalendarItem>
 
 @Render
 

--- a/Heron.MudCalendar.Docs/Pages/Index.razor
+++ b/Heron.MudCalendar.Docs/Pages/Index.razor
@@ -83,7 +83,7 @@
                         </Description>
                     </SectionHeader>
                     <SectionCode>
-                        <pre><span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudCalendar</span><span class="htmlTagDelimiter">/&gt;</span></pre>
+                        <pre><span class="htmlTagDelimiter">&lt;</span><span class="htmlElementName">MudCalendar</span><span class="htmlAttributeName">type</span><span class="T">=</span><span class="quot">"</span><span class="htmlAttributeValue">CalendarItem</span><span class="quot">"</span><span class="htmlTagDelimiter">/&gt;</span></pre>
                     </SectionCode>
                 </DocsPageSection>
 

--- a/Heron.MudCalendar.UnitTests.Viewer/Program.cs
+++ b/Heron.MudCalendar.UnitTests.Viewer/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using Heron.MudCalendar.UnitTests.Viewer;
 using Heron.MudCalendar.UnitTests.Viewer.Services;
 using MudBlazor.Services;
+using Heron.MudCalendar;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -11,6 +12,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddMudServices();
 
-builder.Services.AddScoped<EventService>();
+builder.Services.AddScoped<EventService<CalendarItem>>();
 
 await builder.Build().RunAsync();

--- a/Heron.MudCalendar.UnitTests.Viewer/Services/EventService.cs
+++ b/Heron.MudCalendar.UnitTests.Viewer/Services/EventService.cs
@@ -1,16 +1,17 @@
 using MudBlazor;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Heron.MudCalendar.UnitTests.Viewer.Services;
 
-public class EventService
+public class EventService<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> where T:CalendarItem, new()
 {
-    private readonly Dictionary<DateTime, List<CalendarItem>> _items = new();
+    private readonly Dictionary<DateTime, List<T>> _items = new();
 
-    public List<CalendarItem> GetEvents(DateRange dateRange)
+    public List<T> GetEvents(DateRange dateRange)
     {
-        if (dateRange.Start == null || dateRange.End == null) return new List<CalendarItem>();
+        if (dateRange.Start == null || dateRange.End == null) return new List<T>();
 
-        var events = new List<CalendarItem>();
+        var events = new List<T>();
         var month = new DateTime(dateRange.Start.Value.Year, dateRange.Start.Value.Month, 1);
         while (month <= dateRange.End.Value)
         {
@@ -30,7 +31,7 @@ public class EventService
     private void CreateEvents(DateTime month)
     {
         // Create 20 dummy events
-        var events = new List<CalendarItem>();
+        var events = new List<T>();
         var days = DateTime.DaysInMonth(month.Year, month.Month);
         var rnd = new Random();
         for (var i = 0; i < 20; i++)
@@ -39,7 +40,7 @@ public class EventService
             var hour = rnd.Next(8, 16);
             var duration = rnd.Next(1, 8) / 2.0;
 
-            var item = new CalendarItem
+            var item = new T
             {
                 Start = new DateTime(month.Year, month.Month, day, hour, 0, 0)
             };

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarCellClickTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarCellClickTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar CellClicked="TestClick" MonthCellMinHeight="150" DayTimeInterval="CalendarTimeInterval.Minutes10" />
+<MudCalendar T="CalendarItem" CellClicked="TestClick" MonthCellMinHeight="150" DayTimeInterval="CalendarTimeInterval.Minutes10" />
 <MudTextField @bind-Value="_value" />
 <MudTextField @bind-Value="_timeValue" />
 

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarCurrentDayTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarCurrentDayTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar @bind-CurrentDay="@_currentDay" />
+<MudCalendar T="CalendarItem" @bind-CurrentDay="@_currentDay" />
 
 @code {
 

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarDelayedLoadTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarDelayedLoadTest.razor
@@ -1,9 +1,9 @@
 @using Heron.MudCalendar.UnitTests.Viewer.Services
-@inject EventService EventService
+@inject EventService<CalendarItem> EventService
 
 <MudPopoverProvider />
 
-<MudCalendar Items="_events" Height="1000" DateRangeChanged="DateRangeChanged" EnableDragItems="true" EnableResizeItems="true" />
+<MudCalendar T="CalendarItem" Items="_events" Height="1000" DateRangeChanged="DateRangeChanged" EnableDragItems="true" EnableResizeItems="true" />
 
 @code {
     public static string __description__ = "Calendar Delayed Load Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarDragTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarDragTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudCalendar Items="_events" Height="1000" EnableDragItems="true" EnableResizeItems="true" ItemChanged="ItemChanged" />
+<MudCalendar T="CalendarItem" Items="_events" Height="1000" EnableDragItems="true" EnableResizeItems="true" ItemChanged="ItemChanged" />
 <MudTextField @bind-Value="_value" />
 
 @code {

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarEventsTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarEventsTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar DateRangeChanged="DateRangeChanged" CurrentDayChanged="CurrentDayChanged" />
+<MudCalendar T="CalendarItem" DateRangeChanged="DateRangeChanged" CurrentDayChanged="CurrentDayChanged" />
 
 <div class="d-flex">
     

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarHeightTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarHeightTest.razor
@@ -1,4 +1,4 @@
-<MudCalendar Items="_events" Height="630" MonthCellMinHeight="@(_fixed ? 0 : 115)">
+<MudCalendar T="CalendarItem" Items="_events" Height="630" MonthCellMinHeight="@(_fixed ? 0 : 115)">
     <MonthTemplate>
         <div class="d-flex gap-1">
             <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Secondary" Size="Size.Small"/>

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarInvalidEndDateTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarInvalidEndDateTest.razor
@@ -1,4 +1,4 @@
-<MudCalendar Items="_events" />
+<MudCalendar T="CalendarItem" Items="_events" />
 
 @code {
     public static string __description__ = "Calendar Invalid End Date Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarItemClickTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarItemClickTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar @ref="_mudCalendar" Items="_events" ItemClicked="TestClick" />
+<MudCalendar T="CalendarItem" @ref="_mudCalendar" Items="_events" ItemClicked="TestClick" />
 <MudTextField @bind-Value="_value" />
 
 @code {
@@ -8,7 +8,7 @@
 
     private string _value = string.Empty;
 
-    private MudCalendar _mudCalendar;
+    private MudCalendar<CalendarItem> _mudCalendar;
 
     private void TestClick(CalendarItem item)
     {

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarLongTextTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarLongTextTest.razor
@@ -1,4 +1,4 @@
-<MudCalendar Items="_events" />
+<MudCalendar T="CalendarItem" Items="_events" />
 
 @code {
     public static string __description__ = "Calendar Long Text Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMinItemHeightTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMinItemHeightTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar Items="_events" ShowMonth="false" DayTimeInterval="CalendarTimeInterval.Minutes60" DayCellHeight="100" DayItemMinHeight="90" />
+<MudCalendar T="CalendarItem" Items="_events" ShowMonth="false" DayTimeInterval="CalendarTimeInterval.Minutes60" DayCellHeight="100" DayItemMinHeight="90" />
 
 @code {
     public static string __description__ = "Calendar MinItem Height Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMobileTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMobileTest.razor
@@ -1,7 +1,7 @@
 <MudPopoverProvider></MudPopoverProvider>
 
 <div style="width: 350px; margin-left: auto; margin-right: auto;">
-    <MudCalendar Items="_events" ShowDropdownViewSelector="true" ShowPrevNextButtons="false" ToolbarPadding="4">
+    <MudCalendar T="CalendarItem" Items="_events" ShowDropdownViewSelector="true" ShowPrevNextButtons="false" ToolbarPadding="4">
         <MonthTemplate>
             <div class="d-flex gap-1">
                 <MudIcon Icon="@Icons.Material.Filled.Circle" Color="Color.Primary" Size="Size.Small"/>

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMultiDayEventTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMultiDayEventTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar Items="_events" Height="1000" />
+<MudCalendar T="CalendarItem"  Items="_events" Height="1000" />
 
 @code {
     public static string __description__ = "Calendar Multi-Day Events Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMultiDayMonthTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMultiDayMonthTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider/>
 
-<MudCalendar Items="_events" Height="1000" EnableDragItems="true" EnableResizeItems="true" CellClicked="TestClick" MoreClicked="MoreClicked"/>
+<MudCalendar T="CalendarItem" Items="_events" Height="1000" EnableDragItems="true" EnableResizeItems="true" CellClicked="TestClick" MoreClicked="MoreClicked" />
 <MudTextField @bind-Value="_value"/>
 <MudTextField @bind-Value="_timeValue"/>
 

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarNoToolbarTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarNoToolbarTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudCalendar Height="600" ShowToolbar="false" />
+<MudCalendar T="CalendarItem" Height="600" ShowToolbar="false" />
 
 @code {
     public static string __description__ = "No toolbar Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarOverlappingEventsTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarOverlappingEventsTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar Items="_events" ShowMonth="false"/>
+<MudCalendar T="CalendarItem" Items="_events" ShowMonth="false" />
 
 @code {
     public static string __description__ = "Calendar Overlapping Events Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarSameDayEventsTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarSameDayEventsTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar Items="_events" Height="1000" />
+<MudCalendar T="CalendarItem" Items="_events" Height="1000" />
 
 <MudButton Class="add-item" OnClick="AddItem">Add Item</MudButton>
 

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarStartTimeTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarStartTimeTest.razor
@@ -1,7 +1,7 @@
 @inject IJSRuntime JsRuntime
 @implements IAsyncDisposable
 
-<MudCalendar ShowMonth="false" DayStartTime="new TimeOnly(6, 15)"/>
+<MudCalendar T="CalendarItem" ShowMonth="false" DayStartTime="new TimeOnly(6, 15)"/>
 
 <div class="cal-test-controls">
     <div class="cal-scroll-pos">@_scrollPos</div>

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider></MudPopoverProvider>
 
-<MudCalendar Items="_events" ShowTodayButton="true" ShowWorkWeek="true" />
+<MudCalendar T="CalendarItem" Items="_events" ShowTodayButton="true" ShowWorkWeek="true" />
 
 @code {
     public static string __description__ = "Basic Calendar Tests";

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarTimeIntervalTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarTimeIntervalTest.razor
@@ -1,6 +1,6 @@
 <MudPopoverProvider />
 
-<MudCalendar ShowMonth="false" DayTimeInterval="CalendarTimeInterval.Minutes15" ShowCurrentTime="true" />
+<MudCalendar T="CalendarItem" ShowMonth="false" DayTimeInterval="CalendarTimeInterval.Minutes15" ShowCurrentTime="true" />
 
 @code {
     

--- a/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
+++ b/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
@@ -39,7 +39,7 @@ public class CalendarTests : BunitTest
     public void RestrictViews()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         comp.SetParam(x => x.ShowDay, false);
         comp.SetParam(x => x.ShowWeek, false);
@@ -53,7 +53,7 @@ public class CalendarTests : BunitTest
     public void EnsureViewIsChangedWhenCurrentViewNotAllowed()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         comp.SetParam(x => x.ShowMonth, false);
 
@@ -65,7 +65,7 @@ public class CalendarTests : BunitTest
     public void NextButton()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         comp.SetParam(x => x.FirstDayOfWeek!, DayOfWeek.Monday);
         comp.SetParam(x => x.FirstDayOfWorkWeek!, DayOfWeek.Sunday);
 
@@ -100,7 +100,7 @@ public class CalendarTests : BunitTest
     public void PrevButton()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         comp.SetParam(x => x.FirstDayOfWeek!, DayOfWeek.Monday);
         comp.SetParam(x => x.FirstDayOfWorkWeek!, DayOfWeek.Sunday);
 
@@ -136,7 +136,7 @@ public class CalendarTests : BunitTest
     public void CellClick()
     {
         var cut = Context.RenderComponent<CalendarCellClickTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         var textField = cut.FindComponents<MudTextField<string>>()[0];
         var timeField = cut.FindComponents<MudTextField<string>>()[1];
         
@@ -195,7 +195,7 @@ public class CalendarTests : BunitTest
     public void ItemsClick()
     {
         var cut = Context.RenderComponent<CalendarItemClickTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         var textField = cut.FindComponent<MudTextField<string>>();
         
         // Month View
@@ -217,7 +217,7 @@ public class CalendarTests : BunitTest
     public void EnsureAllDays()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1));
         comp.FindAll("div.mud-cal-month-cell-title").Count.Should().Be(42);
@@ -228,7 +228,7 @@ public class CalendarTests : BunitTest
     public void WeekStartSunday()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         // Check that the first day is a Sunday
         var firstDayDate = comp.FindAll("div.mud-drop-zone")[0].Attributes["identifier"]!.TextContent;
@@ -239,7 +239,7 @@ public class CalendarTests : BunitTest
     public void UpdateDatePicker()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         comp.SetParam(x => x.View, CalendarView.Week);
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 2, 1));
@@ -254,7 +254,7 @@ public class CalendarTests : BunitTest
     public void EventOrder()
     {
         var cut = Context.RenderComponent<CalendarSameDayEventsTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.Find("div.mud-cal-drop-item div.mud-cal-cell-template").TextContent.Should().Be("Event 1");
         
@@ -267,7 +267,7 @@ public class CalendarTests : BunitTest
     public void ViewNameLocalization()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         comp.Find("div.mud-button-group-root button.mud-button-root span.mud-button-label").TextContent.Should()
             .Be("Monat");
@@ -279,7 +279,7 @@ public class CalendarTests : BunitTest
     public void CellsClickable()
     {
         var cut = Context.RenderComponent<CalendarCellClickTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         // Month View
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1));
@@ -300,7 +300,7 @@ public class CalendarTests : BunitTest
     public void CellsNotClickable()
     {
         var cut = Context.RenderComponent<CalendarTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         // Month View
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1));
@@ -321,7 +321,7 @@ public class CalendarTests : BunitTest
     public void OverlappingEvents()
     {
         var cut = Context.RenderComponent<CalendarOverlappingEventsTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.SetParam(x => x.View, CalendarView.Day);
         var event1 = comp.FindAll("div.mud-cal-week-cell-holder > div.mud-cal-drop-item")[0];
@@ -352,7 +352,7 @@ public class CalendarTests : BunitTest
     public void MultiDayWorkWeekView()
     {
         var cut = Context.RenderComponent<CalendarMultiDayEventTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         comp.SetParam(x => x.ShowWorkWeek, true);
         comp.SetParam(x => x.ShowWeek, false);
 
@@ -370,7 +370,7 @@ public class CalendarTests : BunitTest
     public void MultiDayWeekView()
     {
         var cut = Context.RenderComponent<CalendarMultiDayEventTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 2, 1));
         comp.SetParam(x => x.View, CalendarView.Week);
@@ -386,7 +386,7 @@ public class CalendarTests : BunitTest
     public void MultiDayDayView()
     {
         var cut = Context.RenderComponent<CalendarMultiDayEventTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.SetParam(x => x.View, CalendarView.Day);
         
@@ -410,7 +410,7 @@ public class CalendarTests : BunitTest
     public void MultiDayMonthView()
     {
         var cut = Context.RenderComponent<CalendarMultiDayMonthTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.SetParam(x => x.CurrentDay, new DateTime(2024, 11, 1));
         // Should be event 3
@@ -427,7 +427,7 @@ public class CalendarTests : BunitTest
     public void DateChangedEvent()
     {
         var cut = Context.RenderComponent<CalendarEventsTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1));
         
@@ -442,7 +442,7 @@ public class CalendarTests : BunitTest
     public void CurrentDayChangedEvent()
     {
         var cut = Context.RenderComponent<CalendarEventsTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
 
         comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1));
         
@@ -461,7 +461,7 @@ public class CalendarTests : BunitTest
     public void ClockType()
     {
         var cut = Context.RenderComponent<CalendarTimeIntervalTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         // Check 24-hour clock
         comp.FindAll("div.mud-cal-time-cell")[18].TextContent.Trim().Should().Be("18:00");
@@ -475,7 +475,7 @@ public class CalendarTests : BunitTest
     public void CurrentDayTest()
     {
         var cut = Context.RenderComponent<CalendarCurrentDayTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         // Check that current month is Feb 2024
         comp.FindAll(".mud-drop-zone")[0].Attributes["identifier"]!.TextContent.Should().Be("29/01/2024");
@@ -485,7 +485,7 @@ public class CalendarTests : BunitTest
     public void DayItemMinHeightTest()
     {
         var cut = Context.RenderComponent<CalendarMinItemHeightTest>();
-        var comp = cut.FindComponent<MudCalendar>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
         
         comp.SetParam(x => x.View, CalendarView.Day);
         var event1 = comp.FindAll("div.mud-cal-week-cell-holder > div.mud-cal-drop-item")[0];

--- a/Heron.MudCalendar/Base/CalendarViewBase.cs
+++ b/Heron.MudCalendar/Base/CalendarViewBase.cs
@@ -1,13 +1,14 @@
 using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Heron.MudCalendar;
 
-public abstract class CalendarViewBase : ComponentBase
+public abstract class CalendarViewBase<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : ComponentBase where T:CalendarItem
 {
     [CascadingParameter]
-    public MudCalendar Calendar { get; set; } = new();
+    public MudCalendar<T> Calendar { get; set; } = new();
 
-    protected List<CalendarCell> Cells = new();
+    protected List<CalendarCell<T>> Cells = new();
 
     protected override void OnParametersSet()
     {
@@ -17,5 +18,5 @@ public abstract class CalendarViewBase : ComponentBase
     /// <summary>
     /// Builds a collection of cells that will be displayed in the month view.
     /// </summary>
-    protected abstract List<CalendarCell> BuildCells();
+    protected abstract List<CalendarCell<T>> BuildCells();
 }

--- a/Heron.MudCalendar/Base/DayWeekViewBase.razor
+++ b/Heron.MudCalendar/Base/DayWeekViewBase.razor
@@ -1,8 +1,8 @@
 @namespace Heron.MudCalendar
-@inherits CalendarViewBase
+@inherits CalendarViewBase<T>
 @using Microsoft.JSInterop
 @inject IJSRuntime JsRuntime
-
+@typeparam T
 @Render
 
 @code {
@@ -20,7 +20,7 @@
                             <div class="d-block relative">
                                 @RenderTimes
                                 <MudDropContainer
-                                    T="CalendarItem"
+                                    T="T"
                                     Items="Calendar.Items"
                                     ItemsSelector="@((item, dropzone) => item.Id == dropzone)"
                                     ItemDisabled="@(_ => !Calendar.EnableDragItems)"
@@ -59,7 +59,7 @@
     /// <summary>
     /// Renders the title of a day.
     /// </summary>
-    protected virtual RenderFragment RenderDayTitle(CalendarCell cell) => __builder =>
+    protected virtual RenderFragment RenderDayTitle(CalendarCell<T> cell) => __builder =>
     {
         __builder.AddContent(1, cell.Date.ToString("ddd"));
         __builder.AddContent(2, " ");
@@ -110,12 +110,12 @@
     /// <summary>
     /// Renders an individual cell.
     /// </summary>
-    protected virtual RenderFragment RenderCell(CalendarCell cell) =>
+    protected virtual RenderFragment RenderCell(CalendarCell<T> cell) =>
         @<div class="mud-cal-week-cell-holder">
             @for (var i = 0; i < CellsInDay; i++)
             {
                 var row = i;
-                <MudDropZone T="CalendarItem" OnlyZone="true" Style="@CellHeightStyle()" Identifier="@string.Concat(cell.Date.Date.ToString("d"), "_", row.ToString())">
+                <MudDropZone T="T" OnlyZone="true" Style="@CellHeightStyle()" Identifier="@string.Concat(cell.Date.Date.ToString("d"), "_", row.ToString())">
                     @if (Calendar.CellClicked.HasDelegate)
                     {
                         <MudLink @onclick="() => OnCellLinkClicked(cell, row)" Class="mud-cal-week-cell-link">
@@ -130,14 +130,14 @@
     /// <summary>
     /// Renders the contents of a cell.
     /// </summary>
-    protected virtual RenderFragment RenderCellContents(CalendarCell cell) => __builder =>
+    protected virtual RenderFragment RenderCellContents(CalendarCell<T> cell) => __builder =>
     {
         var positions = CalcPositions(cell.Items, DateOnly.FromDateTime(cell.Date));
         foreach (var position in positions)
         {
             if (position.Item.Start.Date == cell.Date.Date)
             {
-                <WeekDropZone Position="position" Style="@EventStyle(position)" @key="position.Item.Id">
+                <WeekDropZone T="T" Position="position" Style="@EventStyle(position)" @key="position.Item.Id">
                     @if (Calendar.EnableResizeItems && !position.Item.IsMultiDay)
                     {
                         <Resizer ContainerClass="mud-cal-week-grid" CellCount="CellsInDay" ResizeX="false" SizeChanged="@(newHeight => ItemHeightChanged(position.Item, newHeight))"/>
@@ -156,7 +156,7 @@
     /// <summary>
     /// Renders the CellTemplate with a click handler if required.
     /// </summary>
-    protected virtual RenderFragment RenderTemplate(CalendarItem item) => __builder =>
+    protected virtual RenderFragment RenderTemplate(T item) => __builder =>
     {
         @if (Calendar.ItemClicked.HasDelegate)
         {

--- a/Heron.MudCalendar/Base/DayWeekViewBase.razor.cs
+++ b/Heron.MudCalendar/Base/DayWeekViewBase.razor.cs
@@ -3,11 +3,12 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
+using System.Diagnostics.CodeAnalysis;
 using EnumExtensions = Heron.MudCalendar.Extensions.EnumExtensions;
 
 namespace Heron.MudCalendar;
 
-public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
+public abstract partial class DayWeekViewBase<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : CalendarViewBase<T>, IDisposable where T:CalendarItem
 {
     private ElementReference _scrollDiv;
     private JsService? _jsService;
@@ -57,7 +58,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
     /// <param name="calendarCell">The cell.</param>
     /// <param name="row">The current row in the table being rendered.</param>
     /// <returns></returns>
-    protected virtual string DayStyle(CalendarCell calendarCell, int row)
+    protected virtual string DayStyle(CalendarCell<T> calendarCell, int row)
     {
         return new StyleBuilder()
             .AddStyle("border-left",
@@ -80,7 +81,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
     /// </summary>
     /// <param name="position">Position information for the div.</param>
     /// <returns></returns>
-    protected virtual string EventStyle(ItemPosition position)
+    protected virtual string EventStyle(ItemPosition<T> position)
     {
         return new StyleBuilder()
             .AddStyle("position", "absolute")
@@ -113,7 +114,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
     /// <param name="cell">The cell being styled.</param>
     /// <param name="row">The row being styled.</param>
     /// <returns></returns>
-    protected virtual string DayCellClassname(CalendarCell cell, int row)
+    protected virtual string DayCellClassname(CalendarCell<T> cell, int row)
     {
         return new CssBuilder()
             .AddClass("mud-cal-week-cell")
@@ -153,7 +154,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
     /// <param name="cell">The cell that was clicked.</param>
     /// <param name="row">The row that was clicked.</param>
     /// <returns></returns>
-    protected virtual Task OnCellLinkClicked(CalendarCell cell, int row)
+    protected virtual Task OnCellLinkClicked(CalendarCell<T> cell, int row)
     {
         var date = cell.Date.AddMinutes(row * (int)Calendar.DayTimeInterval);
         return Calendar.CellClicked.InvokeAsync(date);
@@ -164,7 +165,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
     /// </summary>
     /// <param name="item">The calendar item that was clicked.</param>
     /// <returns></returns>
-    protected virtual Task OnItemClicked(CalendarItem item)
+    protected virtual Task OnItemClicked(T item)
     {
         return Calendar.ItemClicked.InvokeAsync(item);
     }
@@ -201,7 +202,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
     /// <param name="item">The calendar item whose height is changing.</param>
     /// <param name="intervals">The number of intervals by which the item's end time should be extended.</param>
     /// <returns>A task representing the asynchronous operation of invoking the item changed event.</returns>
-    protected Task ItemHeightChanged(CalendarItem item, int intervals)
+    protected Task ItemHeightChanged(T item, int intervals)
     {
         // Calculate end time from height
         var minutes = intervals * (int)Calendar.DayTimeInterval;
@@ -219,7 +220,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
         return position;
     }
 
-    private int CalcTop(ItemPosition position)
+    private int CalcTop(ItemPosition<T> position)
     {
         double minutes = 0;
         if (DateOnly.FromDateTime(position.Item.Start.Date) == position.Date)
@@ -233,7 +234,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
         return (int)Math.Round(top);
     }
 
-    private int CalcHeight(ItemPosition position)
+    private int CalcHeight(ItemPosition<T> position)
     {
         double start = 0;
         if (DateOnly.FromDateTime(position.Item.Start.Date) == position.Date)
@@ -274,12 +275,12 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
         await _jsService.Scroll(_scrollDiv, (int)scrollTo);
     }
 
-    protected virtual RenderFragment<CalendarItem> CellTemplate => Calendar.CellTemplate;
+    protected virtual RenderFragment<T> CellTemplate => Calendar.CellTemplate;
 
-    private IEnumerable<ItemPosition> CalcPositions(IEnumerable<CalendarItem> items, DateOnly date)
+    private IEnumerable<ItemPosition<T>> CalcPositions(IEnumerable<T> items, DateOnly date)
     {
-        var positions = new List<ItemPosition>();
-        var overlaps = new List<ItemPosition>();
+        var positions = new List<ItemPosition<T>>();
+        var overlaps = new List<ItemPosition<T>>();
         foreach (var item in items)
         {
             // Check that the end date is valid
@@ -289,7 +290,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
             }
 
             // Create new position object
-            var position = new ItemPosition { Item = item, Position = 0, Total = overlaps.Count + 1, Date = date };
+            var position = new ItemPosition<T> { Item = item, Position = 0, Total = overlaps.Count + 1, Date = date };
             position.Top = CalcTop(position);
             position.Height = CalcHeight(position);
             if (position.Bottom > PixelsInDay)
@@ -344,7 +345,7 @@ public abstract partial class DayWeekViewBase : CalendarViewBase, IDisposable
         return positions;
     }
 
-    private async Task ItemDropped(MudItemDropInfo<CalendarItem> dropItem)
+    private async Task ItemDropped(MudItemDropInfo<T> dropItem)
     {
         if (dropItem.Item == null) return;
         var item = dropItem.Item;

--- a/Heron.MudCalendar/Components/CalendarCell.cs
+++ b/Heron.MudCalendar/Components/CalendarCell.cs
@@ -1,10 +1,12 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Heron.MudCalendar;
 
-public class CalendarCell
+public class CalendarCell<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> where T: CalendarItem
 {
     public DateTime Date { get; set; }
 
-    public IEnumerable<CalendarItem> Items { get; set; } = new List<CalendarItem>();
+    public IEnumerable<T> Items { get; set; } = new List<T>();
     
     public bool Outside { get; set; }
     

--- a/Heron.MudCalendar/Components/CalendarItem.cs
+++ b/Heron.MudCalendar/Components/CalendarItem.cs
@@ -1,11 +1,13 @@
+using static MudBlazor.Colors;
+
 namespace Heron.MudCalendar;
 
 public class CalendarItem
 {
     public DateTime Start { get; set; }
-    
+
     public DateTime? End { get; set; }
-    
+
     public bool AllDay { get; set; }
 
     public string Text { get; set; } = string.Empty;

--- a/Heron.MudCalendar/Components/DayView.cs
+++ b/Heron.MudCalendar/Components/DayView.cs
@@ -1,14 +1,15 @@
 using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Heron.MudCalendar;
 
-public class DayView : DayWeekViewBase
+public class DayView<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : DayWeekViewBase<T> where T:CalendarItem
 {
     protected override int DaysInView => 1;
 
-    protected override List<CalendarCell> BuildCells()
+    protected override List<CalendarCell<T>> BuildCells()
     {
-        var cell = new CalendarCell { Date = Calendar.CurrentDay.Date };
+        var cell = new CalendarCell<T> { Date = Calendar.CurrentDay.Date };
         if (Calendar.CurrentDay.Date == DateTime.Today) cell.Today = true;
         
         cell.Items = Calendar.Items.Where(i =>
@@ -17,8 +18,8 @@ public class DayView : DayWeekViewBase
             .OrderBy(i => i.Start)
             .ToList();
         
-        return new List<CalendarCell> { cell };
+        return new List<CalendarCell<T>> { cell };
     }
 
-    protected override RenderFragment<CalendarItem> CellTemplate => Calendar.DayTemplate ?? Calendar.CellTemplate;
+    protected override RenderFragment<T> CellTemplate => Calendar.DayTemplate ?? Calendar.CellTemplate;
 }

--- a/Heron.MudCalendar/Components/ItemPosition.cs
+++ b/Heron.MudCalendar/Components/ItemPosition.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
+
 namespace Heron.MudCalendar;
 
-public class ItemPosition
+public class ItemPosition<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T>  where T : CalendarItem
 {
-    public CalendarItem Item { get; set; } = new();
+    public T Item { get; set; } = (T)Activator.CreateInstance(typeof(T));
     public int Position { get; set; }
     public int Total { get; set; }
     public DateOnly Date { get; set; }

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -1,7 +1,8 @@
 @namespace Heron.MudCalendar
 @using Microsoft.JSInterop
-@inherits CalendarViewBase
+@inherits CalendarViewBase<T>
 @inject IJSRuntime JsRuntime
+@typeparam T
 
 @Render
 
@@ -17,7 +18,7 @@
                 @* @RenderDays *@
                 <MudDropContainer
                     @ref="_dropContainer"
-                    T="CalendarItem"
+                    T="T"
                     Items="Calendar.Items.OrderBy(i => i.Start)"
                     ItemsSelector="@((item, dropzone) => item.Id == dropzone)"
                     ItemDisabled="@(_ => !Calendar.EnableDragItems)"
@@ -86,7 +87,7 @@
                 @for (var cell = row * Columns; cell < (row * Columns) + Columns; cell++)
                 {
                     var currentCell = Cells[cell];
-                    <MudDropZone T="CalendarItem" OnlyZone="true" Identifier="@currentCell.Date.Date.ToString("d")"
+                    <MudDropZone T="T" OnlyZone="true" Identifier="@currentCell.Date.Date.ToString("d")"
                                  Class="@CellClassname" Style="@DayStyle(currentCell, cell)">
                         @if (Calendar.CellClicked.HasDelegate)
                         {
@@ -110,7 +111,7 @@
     /// <summary>
     /// Renders the day number of the cell.
     /// </summary>
-    protected virtual RenderFragment RenderCellDayNumber(CalendarCell cell) =>
+    protected virtual RenderFragment RenderCellDayNumber(CalendarCell<T> cell) =>
         @<div class="@DayClassname(cell)">
             @cell.Date.Day
         </div>;
@@ -128,7 +129,7 @@
             {
                 if (position.Item.Start.Date == currentCell.Date.Date)
                 {
-                    <WeekDropZone Position="position" Style="@EventStyle(position)" @key="position.Item.Id">
+                    <WeekDropZone T="T" Position="position" Style="@EventStyle(position)" @key="position.Item.Id">
                         @RenderResizer(position, currentCell)
                     </WeekDropZone>
                 }
@@ -146,7 +147,7 @@
     /// <summary>
     /// Renders the resizer for the item if necessary.
     /// </summary>
-    protected virtual RenderFragment RenderResizer(ItemPosition position, CalendarCell cell) => __builder =>
+    protected virtual RenderFragment RenderResizer(ItemPosition<T> position, CalendarCell<T> cell) => __builder =>
     {
         @if (Calendar.EnableResizeItems)
         {
@@ -158,7 +159,7 @@
     /// <summary>
     /// Renders the CellTemplate with a click handler if required.
     /// </summary>
-    protected virtual RenderFragment RenderTemplate(CalendarItem item) => __builder =>
+    protected virtual RenderFragment RenderTemplate(T item) => __builder =>
     {
         @if (Calendar.ItemClicked.HasDelegate)
         {

--- a/Heron.MudCalendar/Components/MudCalendar.razor
+++ b/Heron.MudCalendar/Components/MudCalendar.razor
@@ -3,6 +3,7 @@
 @using CategoryTypes = Heron.MudCalendar.Attributes.CategoryTypes
 @using Microsoft.JSInterop
 @inject IJSRuntime JsRuntime
+@typeparam T
 
 @Render
 
@@ -50,7 +51,7 @@
     /// </summary>
     [Attributes.Category(CategoryTypes.Calendar.Template)]
     [Parameter]
-    public RenderFragment<CalendarItem> CellTemplate { get; set; } =
+    public RenderFragment<T> CellTemplate { get; set; } =
         calendarItem =>
             @<div class="mud-cal-cell-template">
                 <MudChip T="string" Label="true" Color="Color.Primary" Class="mud-cal-cell-template-chip">@calendarItem.Text</MudChip>
@@ -98,25 +99,25 @@
     /// Renders the month view.
     /// </summary>
     protected virtual RenderFragment RenderMonthView =>
-        @<MonthView />;
+        @<MonthView T="T"/>;
 
     /// <summary>
     /// Renders the week view.
     /// </summary>
     protected virtual RenderFragment RenderWeekView =>
-        @<WeekView />;
+        @<WeekView T="T" />;
 
 
     /// <summary>
     /// Renders the work week view.
     /// </summary>
     protected virtual RenderFragment RenderWorkWeekView =>
-        @<WorkWeekView />;
+        @<WorkWeekView T="T" />;
 
     /// <summary>
     /// Renders the day view.
     /// </summary>
     protected virtual RenderFragment RenderDayView =>
-        @<DayView />;
+        @<DayView T="T" />;
 
 }

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -8,13 +8,16 @@ using MudBlazor.Utilities;
 using MudBlazor;
 using CategoryAttribute = Heron.MudCalendar.Attributes.CategoryAttribute;
 using CategoryTypes = Heron.MudCalendar.Attributes.CategoryTypes;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.JSInterop;
 
 namespace Heron.MudCalendar;
 
 /// <summary>
-///  Calendar component for MudBlazor.
+/// Calendar component for MudBlazor.
 /// </summary>
-public partial class MudCalendar : MudComponentBase
+/// <typeparam name="T">The type of item displayed in this calendar.</typeparam>
+public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : MudComponentBase where T : CalendarItem
 {
     /// <summary>
     /// The size of the drop shadow.
@@ -328,7 +331,7 @@ public partial class MudCalendar : MudComponentBase
     /// </remarks>
     [Category(CategoryTypes.Calendar.Template)]
     [Parameter]
-    public RenderFragment<CalendarItem>? MonthTemplate { get; set; }
+    public RenderFragment<T>? MonthTemplate { get; set; }
     
     /// <summary>
     /// Defines the cell content for the Week view.
@@ -338,7 +341,7 @@ public partial class MudCalendar : MudComponentBase
     /// </remarks>
     [Category(CategoryTypes.Calendar.Template)]
     [Parameter]
-    public RenderFragment<CalendarItem>? WeekTemplate { get; set; }
+    public RenderFragment<T>? WeekTemplate { get; set; }
     
     /// <summary>
     /// Defines the cell content for the Day view.
@@ -348,7 +351,7 @@ public partial class MudCalendar : MudComponentBase
     /// </remarks>
     [Category(CategoryTypes.Calendar.Template)]
     [Parameter]
-    public RenderFragment<CalendarItem>? DayTemplate { get; set; }
+    public RenderFragment<T>? DayTemplate { get; set; }
     
     /// <summary>
     /// Custom content to appear in the toolbar of the component.
@@ -365,7 +368,7 @@ public partial class MudCalendar : MudComponentBase
     /// </summary>
     [Category(CategoryTypes.Calendar.Behavior)]
     [Parameter]
-    public IEnumerable<CalendarItem> Items { get; set; } = new List<CalendarItem>();
+    public IEnumerable<T> Items { get; set; } = new List<T>();
     
     /// <summary>
     /// Called when the dates visible in the Calendar change.
@@ -383,7 +386,7 @@ public partial class MudCalendar : MudComponentBase
     /// Called when an item is changed, for example by dragging or resizing the item.
     /// </summary>
     [Parameter]
-    public EventCallback<CalendarItem> ItemChanged { get; set; }
+    public EventCallback<T> ItemChanged { get; set; }
 
     /// <summary>
     /// Called when the View is changed.
@@ -401,7 +404,7 @@ public partial class MudCalendar : MudComponentBase
     /// Called when a CalendarItem is clicked.
     /// </summary>
     [Parameter]
-    public EventCallback<CalendarItem> ItemClicked { get; set; }
+    public EventCallback<T> ItemClicked { get; set; }
     
     /// <summary>
     /// Called when the '+x more' label is clicked in the month view.
@@ -621,7 +624,7 @@ public partial class MudCalendar : MudComponentBase
 
         var options = Options.Create(new LocalizationOptions { ResourcesPath = "Resources" });
         var factory = new ResourceManagerStringLocalizerFactory(options, NullLoggerFactory.Instance);
-        var localizer = new StringLocalizer<MudCalendar>(factory);
+        var localizer = new StringLocalizer<MudCalendar<T>>(factory);
 
         _uiCulture = Thread.CurrentThread.CurrentUICulture;
         _todayText = localizer["Today"];

--- a/Heron.MudCalendar/Components/WeekDropZone.razor
+++ b/Heron.MudCalendar/Components/WeekDropZone.razor
@@ -1,9 +1,10 @@
 @using Microsoft.JSInterop
 @namespace Heron.MudCalendar
 @inject IJSRuntime JsRuntime
+@typeparam T
 
 <div Class="@Classname" Style="@Style">
-    <MudDropZone T="CalendarItem" Identifier="@Position?.Item.Id" Style="height: 100%;">
+    <MudDropZone T="T" Identifier="@Position?.Item.Id" Style="height: 100%;">
         @ChildContent
     </MudDropZone>
 </div>

--- a/Heron.MudCalendar/Components/WeekDropZone.razor.cs
+++ b/Heron.MudCalendar/Components/WeekDropZone.razor.cs
@@ -1,13 +1,14 @@
 using Heron.MudCalendar.Services;
 using Microsoft.AspNetCore.Components;
 using MudBlazor.Utilities;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Heron.MudCalendar;
 
-public partial class WeekDropZone : IDisposable
+public partial class WeekDropZone<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : IDisposable where T : CalendarItem
 {
     [CascadingParameter]
-    public MudCalendar Calendar { get; set; } = new();
+    public MudCalendar<T> Calendar { get; set; } = new();
     
     private string _id = Guid.NewGuid().ToString();
 
@@ -17,7 +18,7 @@ public partial class WeekDropZone : IDisposable
     public RenderFragment? ChildContent { get; set; }
     
     [Parameter]
-    public ItemPosition? Position { get; set; }
+    public ItemPosition<T>? Position { get; set; }
     
     [Parameter]
     public string? Style { get; set; }

--- a/Heron.MudCalendar/Components/WeekView.cs
+++ b/Heron.MudCalendar/Components/WeekView.cs
@@ -1,14 +1,15 @@
 using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Heron.MudCalendar;
 
-public class WeekView : DayWeekViewBase
+public class WeekView<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : DayWeekViewBase<T> where T:CalendarItem
 {
     protected override int DaysInView => 7;
     
-    protected override List<CalendarCell> BuildCells()
+    protected override List<CalendarCell<T>> BuildCells()
     {
-        var cells = new List<CalendarCell>();
+        var cells = new List<CalendarCell<T>>();
         var range = new CalendarDateRange(Calendar.CurrentDay.Date, CalendarView.Week, Calendar.FirstDayOfWeek);
         
         if (range.Start == null || range.End == null) return cells;
@@ -17,7 +18,7 @@ public class WeekView : DayWeekViewBase
         var lastDate = range.End.Value;
         while (date <= lastDate)
         {
-            var cell = new CalendarCell { Date = date };
+            var cell = new CalendarCell<T> { Date = date };
             if (date.Date == DateTime.Today) cell.Today = true;
             
             cell.Items = Calendar.Items.Where(i =>
@@ -35,5 +36,5 @@ public class WeekView : DayWeekViewBase
         return cells;
     }
     
-    protected override RenderFragment<CalendarItem> CellTemplate => Calendar.WeekTemplate ?? Calendar.CellTemplate;
+    protected override RenderFragment<T> CellTemplate => Calendar.WeekTemplate ?? Calendar.CellTemplate;
 }

--- a/Heron.MudCalendar/Components/WorkWeekView.cs
+++ b/Heron.MudCalendar/Components/WorkWeekView.cs
@@ -1,14 +1,15 @@
 using Microsoft.AspNetCore.Components;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Heron.MudCalendar;
 
-public class WorkWeekView : DayWeekViewBase
+public class WorkWeekView<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> : DayWeekViewBase<T> where T:CalendarItem
 {
     protected override int DaysInView => 5;
 
-    protected override List<CalendarCell> BuildCells()
+    protected override List<CalendarCell<T>> BuildCells()
     {
-        var cells = new List<CalendarCell>();
+        var cells = new List<CalendarCell<T>>();
         var range = new CalendarDateRange(Calendar.CurrentDay.Date, CalendarView.WorkWeek, Calendar.GetFirstDayOfWeekByCalendarView(CalendarView.WorkWeek));
 
         if (range.Start == null || range.End == null) return cells;
@@ -17,7 +18,7 @@ public class WorkWeekView : DayWeekViewBase
         var lastDate = range.End.Value;
         while (date <= lastDate)
         {
-            var cell = new CalendarCell { Date = date };
+            var cell = new CalendarCell<T> { Date = date };
             if (date.Date == DateTime.Today) cell.Today = true;
 
             cell.Items = Calendar.Items.Where(i =>
@@ -35,5 +36,5 @@ public class WorkWeekView : DayWeekViewBase
         return cells;
     }
 
-    protected override RenderFragment<CalendarItem> CellTemplate => Calendar.WeekTemplate ?? Calendar.CellTemplate;
+    protected override RenderFragment<T> CellTemplate => Calendar.WeekTemplate ?? Calendar.CellTemplate;
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Add style and script references (optional). This step shouldn't be necessary as 
 Add the MudCalendar component to your razor page/component.
 
 ```razor
-<MudCalendar />
+<MudCalendar T="CalendarItem"/>
 ```
 
 Check out the examples of how to use and customize the MudCalendar component.


### PR DESCRIPTION
This PR Implements strongly typed CalendarItems with the new T generic parameter in Heron.MudCalendar in response to [Issue 226](https://github.com/danheron/Heron.MudCalendar/issues/226). This improvement ensures better type checking and easier maintenance of calendar-related events.
