### PR TITLE
Fix overflow issue in Chrome

### DIFF
--- a/Heron.MudCalendar/Styles/Heron.MudCalendar.css
+++ b/Heron.MudCalendar/Styles/Heron.MudCalendar.css
@@ -46,7 +46,7 @@
   display: flex;
   justify-content: space-between;
   column-gap: 4px;
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 .mud-calendar .mud-cal-toolbar .mud-button-label {
   white-space: nowrap;


### PR DESCRIPTION
There are ugly arrows in Chrome.

Tested in both Chrome and Firefox. No changes in Firefox and with this change it works the same in Chrome and in Firefox.

![2025-03-06_22h03_19](https://github.com/user-attachments/assets/fd0df0cf-62d8-4b74-9a47-5b0f8fd34d5d)
