### PR TITLE
Add parameter CellContextMenuClicked

### DIFF
--- a/Heron.MudCalendar.Docs/Pages/Calendar/CalendarPage.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/CalendarPage.razor
@@ -103,6 +103,7 @@
             <SectionHeader Title="Events">
                 <Description>
                     The <CodeInline>CellClicked</CodeInline> event will be raised when a calendar cell is clicked. This can be used, for example, to add new events to the calendar.
+                    The <CodeInline>CellContextMenuClicked</CodeInline> event will be raised when a calendar cell is right-clicked. As the name implies, it allows for example to open a context menu related to a specific cell.
                     The <CodeInline>ItemClicked</CodeInline> event will be raised when an item in the calendar is clicked.
                 </Description>
             </SectionHeader>

--- a/Heron.MudCalendar.Docs/Pages/Calendar/Examples/EventsCalendarExample.razor
+++ b/Heron.MudCalendar.Docs/Pages/Calendar/Examples/EventsCalendarExample.razor
@@ -1,6 +1,16 @@
 @namespace Heron.MudCalendar.Docs.Examples
 
-<MudCalendar T="CalendarItem" Items="_events" CellClicked="CellClicked" ItemClicked="ItemClicked" DayTimeInterval="CalendarTimeInterval.Minutes15" />
+<MudCalendar T="CalendarItem" Items="_events" CellClicked="CellClicked" ItemClicked="ItemClicked" CellContextMenuClicked="OpenMenuContent" DayTimeInterval="CalendarTimeInterval.Minutes15" />
+
+<MudMenu PositionAtCursor="true" @ref="_contextMenu">
+    <MudMenuItem Icon="@Icons.Material.Filled.Add" OnClick="AddEvent">
+        Add an event
+    </MudMenuItem>
+    <MudMenuItem Icon="@Icons.Material.Filled.Delete" OnClick="RemoveAllEvents">
+        Delete all events in this cell
+    </MudMenuItem>
+</MudMenu>
+
 
 @code {
 
@@ -16,6 +26,27 @@
     {
         return DialogService.ShowMessageBox("Item Clicked", item.Text);
     }
+
+    private DateTime? _contextMenuDate;
+    private MudMenu _contextMenu = null!;
+
+    private async Task OpenMenuContent(CalendarClickEventArgs args)
+    {
+        _contextMenuDate = args.DateTime;
+        await _contextMenu.OpenMenuAsync(args.MouseEventArgs);
+    }
+
+    private Task AddEvent()
+    {
+        return DialogService.ShowMessageBox("Adding an event", _contextMenuDate.Value.ToString(Thread.CurrentThread.CurrentCulture));
+    }
+
+
+    private Task RemoveAllEvents()
+    {
+        return DialogService.ShowMessageBox("Removing all events", _contextMenuDate.Value.ToString(Thread.CurrentThread.CurrentCulture));
+    }
+
 
     private List<CalendarItem> _events = new()
     {

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarCellContextMenuClickTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarCellContextMenuClickTest.razor
@@ -1,0 +1,19 @@
+<MudPopoverProvider />
+
+<MudCalendar T="CalendarItem" CellContextMenuClicked="TestClick" MonthCellMinHeight="150" DayTimeInterval="CalendarTimeInterval.Minutes10" />
+<MudTextField @bind-Value="_value" />
+<MudTextField @bind-Value="_timeValue" />
+
+@code {
+    public static string __description__ = "Cell Context Menu Click Test";
+
+    private string _value = string.Empty;
+    private string _timeValue = string.Empty;
+
+    private void TestClick(CalendarClickEventArgs calendarClickEventArgs)
+    {
+		var dateTime = calendarClickEventArgs.DateTime;
+        _value = dateTime.Day.ToString();
+        _timeValue = dateTime.ToShortTimeString();
+    }
+}

--- a/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
+++ b/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
@@ -192,6 +192,66 @@ public class CalendarTests : BunitTest
     }
 
     [Test]
+    public void CellContextMenuClick()
+    {
+        var cut = Context.RenderComponent<CalendarCellContextMenuClickTest>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
+        var textField = cut.FindComponents<MudTextField<string>>()[0];
+        var timeField = cut.FindComponents<MudTextField<string>>()[1];
+        
+        // Month View
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1));
+        comp.Find("div.mud-drop-zone a").ContextMenu();
+        textField.Instance.Text.Should().Be("26");
+        timeField.Instance.Text.Should().Be("00:00");
+        
+        // Month View set with time
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 1, 9, 30, 0));
+        comp.Find("div.mud-drop-zone a").ContextMenu();
+        textField.Instance.Text.Should().Be("26");
+        timeField.Instance.Text.Should().Be("00:00");
+
+        // Work Week View
+        comp.SetParam(x => x.View, CalendarView.WorkWeek);
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 13));
+        comp.Find("div.mud-cal-week-layer a").ContextMenu();
+        textField.Instance.Text.Should().Be("13");
+        
+        // Work Week View set with time
+        comp.SetParam(x => x.View, CalendarView.WorkWeek);
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 13, 9, 30, 0));
+        comp.FindAll("div.mud-cal-week-layer a")[55].ContextMenu();
+        textField.Instance.Text.Should().Be("13");
+        timeField.Instance.Text.Should().Be("09:10");
+
+        // Week View
+        comp.SetParam(x => x.View, CalendarView.Week);
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 13));
+        comp.Find("div.mud-cal-week-layer a").ContextMenu();
+        textField.Instance.Text.Should().Be("9");
+        
+        // Week View set with time
+        comp.SetParam(x => x.View, CalendarView.Week);
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 13, 9, 30, 0));
+        comp.FindAll("div.mud-cal-week-layer a")[55].ContextMenu();
+        textField.Instance.Text.Should().Be("9");
+        timeField.Instance.Text.Should().Be("09:10");
+        
+        // Day View
+        comp.SetParam(x => x.View, CalendarView.Day);
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 8));
+        comp.FindAll("div.mud-cal-week-layer a")[55].ContextMenu();
+        timeField.Instance.Text.Should().Be("09:10");
+        
+        // Day View set with time
+        comp.SetParam(x => x.View, CalendarView.Day);
+        comp.SetParam(x => x.CurrentDay, new DateTime(2023, 1, 8, 9, 30, 0));
+        comp.FindAll("div.mud-cal-week-layer a")[55].ContextMenu();
+        timeField.Instance.Text.Should().Be("09:10");   
+    }
+
+
+    [Test]
     public void DisabledDaysCellClick()
     {
         var cut = Context.RenderComponent<CalendarDisableDaysTest>();

--- a/Heron.MudCalendar/Base/DayWeekViewBase.razor
+++ b/Heron.MudCalendar/Base/DayWeekViewBase.razor
@@ -116,11 +116,26 @@
             var row = i;
             <MudDropZone T="T" OnlyZone="true" Style="@CellHeightStyle()" Identifier="@string.Concat(cell.Date.Date.ToString("d"), "_", row.ToString())"
                          CanDrop="@(item => Calendar.CanDropItem == null || Calendar.CanDropItem(item, cell.Date.AddMinutes(row * (int)Calendar.DayTimeInterval), View))">
-                @if (AllowCellLinkClick(cell, row))
+                @if (AllowCellLinkClick(cell, row) && AllowCellLinkContextMenuClick(cell, row))
                 {
-                    <MudLink @onclick="() => OnCellLinkClicked(cell, row)" Class="mud-cal-week-cell-link">
+                    <a @onclick="() => OnCellLinkClicked(cell, row)" @onclick:preventDefault
+                       @oncontextmenu="(mouseEventArgs) => OnCellLinkContextMenuClicked(mouseEventArgs, cell, row)" @oncontextmenu:preventDefault 
+                       class="mud-cal-week-cell-link">
                         <div class="mud-cal-week-link"></div>
-                    </MudLink>
+                    </a>
+                }
+                else if (AllowCellLinkContextMenuClick(cell, row))
+                {
+                    <a @oncontextmenu="(mouseEventArgs) => OnCellLinkContextMenuClicked(mouseEventArgs, cell, row)" @oncontextmenu:preventDefault
+                       class="mud-cal-week-cell-link">
+                        <div class="mud-cal-week-link" style="cursor: auto"></div>
+                    </a>
+                }
+                else if (AllowCellLinkClick(cell,row)) {
+                    <a @onclick="() => OnCellLinkClicked(cell, row)" 
+                       class="mud-cal-week-cell-link">
+                        <div class="mud-cal-week-link"></div>
+                    </a>
                 }
             </MudDropZone>
         }

--- a/Heron.MudCalendar/Base/DayWeekViewBase.razor
+++ b/Heron.MudCalendar/Base/DayWeekViewBase.razor
@@ -128,7 +128,7 @@
                 {
                     <a @oncontextmenu="(mouseEventArgs) => OnCellLinkContextMenuClicked(mouseEventArgs, cell, row)" @oncontextmenu:preventDefault
                        class="mud-cal-week-cell-link">
-                        <div class="mud-cal-week-link" style="cursor: auto"></div>
+                        <div class="mud-cal-week-link cursor-auto"></div>
                     </a>
                 }
                 else if (AllowCellLinkClick(cell,row)) {

--- a/Heron.MudCalendar/Base/DayWeekViewBase.razor.cs
+++ b/Heron.MudCalendar/Base/DayWeekViewBase.razor.cs
@@ -1,5 +1,6 @@
 using Heron.MudCalendar.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using MudBlazor;
 using MudBlazor.Extensions;
 using MudBlazor.Utilities;
@@ -174,6 +175,33 @@ public abstract partial class DayWeekViewBase<[DynamicallyAccessedMembers(Dynami
     {
         var date = cell.Date.AddMinutes(row * (int)Calendar.DayTimeInterval);
         return Calendar.CellClicked.HasDelegate && (Calendar.IsDateTimeDisabledFunc == null || !Calendar.IsDateTimeDisabledFunc(date, View));
+    }
+
+    /// <summary>
+    /// Method invoked when the user right-clicks on the hyper link in the cell.
+    /// </summary>
+    /// <param name="cell">The cell that was clicked.</param>
+    /// <param name="row">The row that was clicked.</param>
+    /// <returns></returns>
+    protected virtual async Task OnCellLinkContextMenuClicked(MouseEventArgs mouseEventArgs, CalendarCell<T> cell, int row)
+    {
+        if (AllowCellLinkContextMenuClick(cell, row))
+        {
+            var date = cell.Date.AddMinutes(row * (int)Calendar.DayTimeInterval);
+            await Calendar.CellContextMenuClicked.InvokeAsync(new CalendarClickEventArgs(mouseEventArgs,date));
+        }
+    }
+
+    /// <summary>
+    /// Determines if the context menu event is allowed on a cell.
+    /// </summary>
+    /// <param name="cell">The cell that was clicked.</param>
+    /// <param name="row">The row that was clicked.</param>
+    /// <returns><c>true</c> if the cell can be clicked.</returns>
+    protected virtual bool AllowCellLinkContextMenuClick(CalendarCell<T> cell, int row)
+    {
+        var date = cell.Date.AddMinutes(row * (int)Calendar.DayTimeInterval);
+        return Calendar.CellContextMenuClicked.HasDelegate && (Calendar.IsDateTimeDisabledFunc == null || !Calendar.IsDateTimeDisabledFunc(date, View));
     }
 
     /// <summary>

--- a/Heron.MudCalendar/Components/CalendarClickEventArgs.cs
+++ b/Heron.MudCalendar/Components/CalendarClickEventArgs.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Microsoft.AspNetCore.Components.Web;
+
+namespace MudBlazor;
+
+#nullable enable
+
+/// <summary>
+/// Represents the information related to a <see cref="MudCalendar.CellContextMenuClicked"/> event.
+/// </summary>
+public class CalendarClickEventArgs : EventArgs
+{
+    /// <summary>
+    /// The coordinates of the pointer for this click.
+    /// </summary>
+    public MouseEventArgs MouseEventArgs { get; }
+
+    /// <summary>
+    /// The date and time corresponding to the cell which was clicked.
+    /// </summary>
+    public DateTime DateTime { get; }
+
+    /// <summary>
+    /// Creates a new instance.
+    /// </summary>
+    /// <param name="mouseEventArgs">The coordinates of the pointer for this click.</param>
+    /// <param name="item">The date and time corresponding to the cell which was clicked.</param>
+    public CalendarClickEventArgs(MouseEventArgs mouseEventArgs, DateTime dateTime)
+    {
+        MouseEventArgs = mouseEventArgs;
+        DateTime = dateTime;
+    }
+}

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -89,7 +89,7 @@
                         {
                             <a @oncontextmenu="(mouseEventArgs) => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell)" @oncontextmenu:preventDefault
                                class="mud-cal-month-cell-link">
-                                <div class="mud-cal-month-link" style="cursor: auto">
+                                <div class="mud-cal-month-link cursor-auto">
                                     @RenderCellDayNumber(currentCell)
                                 </div>
                             </a>

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -75,9 +75,29 @@
                     <MudDropZone T="T" OnlyZone="true" Identifier="@currentCell.Date.Date.ToString("d")"
                                  Class="@CellClassname(currentCell)" Style="@DayStyle(currentCell, cell)"
                                  CanDrop="@(item => Calendar.CanDropItem == null || Calendar.CanDropItem(item, currentCell.Date, CalendarView.Month))">
-                        @if (AllowCellLinkClick(currentCell))
+                        @if (AllowCellLinkClick(currentCell) && AllowCellLinkContextMenuClick(currentCell))
                         {
-                            <a @onclick="() => OnCellLinkClicked(currentCell)" class="mud-cal-month-cell-link">
+                            <a @onclick="() => OnCellLinkClicked(currentCell)"
+                               @oncontextmenu="(mouseEventArgs) => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell)" @oncontextmenu:preventDefault
+                               class="mud-cal-month-cell-link">
+                                <div class="mud-cal-month-link">
+                                    @RenderCellDayNumber(currentCell)
+                                </div>
+                            </a>
+                        }
+                        else if (AllowCellLinkContextMenuClick(currentCell))
+                        {
+                            <a @oncontextmenu="(mouseEventArgs) => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell)" @oncontextmenu:preventDefault
+                               class="mud-cal-month-cell-link">
+                                <div class="mud-cal-month-link" style="cursor: auto">
+                                    @RenderCellDayNumber(currentCell)
+                                </div>
+                            </a>
+                        }
+                        else if (AllowCellLinkClick(currentCell))
+                        {
+                            <a @onclick="() => OnCellLinkClicked(currentCell)" 
+                               class="mud-cal-month-cell-link">
                                 <div class="mud-cal-month-link">
                                     @RenderCellDayNumber(currentCell)
                                 </div>

--- a/Heron.MudCalendar/Components/MonthView.razor.cs
+++ b/Heron.MudCalendar/Components/MonthView.razor.cs
@@ -2,6 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Heron.MudCalendar.Services;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
@@ -150,6 +151,29 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     protected virtual bool AllowCellLinkClick(CalendarCell<T> cell)
     {
         return Calendar.CellClicked.HasDelegate && (Calendar.IsDateTimeDisabledFunc == null || !Calendar.IsDateTimeDisabledFunc(cell.Date, CalendarView.Month));
+    }
+
+    /// <summary>
+    /// Method invoked when the user right-clicks on the hyperlink in the cell.
+    /// </summary>
+    /// <param name="cell">The cell that was clicked.</param>
+    /// <returns></returns>
+    protected virtual async Task OnCellLinkContextMenuClicked(MouseEventArgs mouseEventArgs, CalendarCell<T> cell)
+    {
+        if (AllowCellLinkContextMenuClick(cell))
+        {
+            await Calendar.CellContextMenuClicked.InvokeAsync(new CalendarClickEventArgs(mouseEventArgs,cell.Date));
+        }
+    }
+
+    /// <summary>
+    /// Determines if the right click event is allowed on a cell.
+    /// </summary>
+    /// <param name="cell">The cell that was clicked.</param>
+    /// <returns><c>true</c> if the cell can be clicked.</returns>
+    protected virtual bool AllowCellLinkContextMenuClick(CalendarCell<T> cell)
+    {
+        return Calendar.CellContextMenuClicked.HasDelegate && (Calendar.IsDateTimeDisabledFunc == null || !Calendar.IsDateTimeDisabledFunc(cell.Date, CalendarView.Month));
     }
 
     protected override void OnParametersSet()

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -455,6 +455,12 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     public EventCallback<DateTime> CellClicked { get; set; }
     
     /// <summary>
+    /// Called when a cell is right-clicked.
+    /// </summary>
+    [Parameter]
+    public EventCallback<CalendarClickEventArgs> CellContextMenuClicked { get; set; }
+
+    /// <summary>
     /// Called when a CalendarItem is clicked.
     /// </summary>
     [Parameter]


### PR DESCRIPTION
Improvement on #265 

- I wanted to block the browser's context menu, but only in case there is an event handler for CellContextMenuClicked.
- I wanted to have the cursor change to pointer only if there is an event handler for CellClick
- I wanted the MouseEventArgs to be carried through to the CellContextMenuClicked event handler as it's required to open a MudMenu

I also added some unit tests, and updated the docs. However, even with following the instructions to build with docs, using your branch of MudBlazor, despite trying my best, I was unable to build the Docs project so I cannot be sure it's working :( . Could you try for me please?