### PR TITLE
Add Support for Customizing the DatePicker's Minimum and Maxium Selectable Dates

### DIFF
--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMinMaxPickerDateTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarMinMaxPickerDateTest.razor
@@ -1,0 +1,12 @@
+<MudPopoverProvider />
+
+<MudCalendar T="CalendarItem" ShowDatePicker="true" ShowToolbar="true" @bind-CurrentDay="@_currentDay" @bind-PickerMinDate="@_minDate" @bind-PickerMaxDate="@_maxDate" />
+
+@code {
+
+    public static string __description__ = "MinMax Picker Date Tests";
+
+    private DateTime _currentDay = new DateTime(2025, 2, 12);
+    private DateTime? _minDate = new DateTime(2024, 1, 1);
+    private DateTime? _maxDate = new DateTime(2026, 12, 31);
+}

--- a/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
+++ b/Heron.MudCalendar.UnitTests/Components/CalendarTests.cs
@@ -642,4 +642,18 @@ public class CalendarTests : BunitTest
         event6.Attributes["style"].Should().NotBeNull();
         event6.Attributes["style"]?.Value.Should().Contain("height:50");
     }
+
+    [Test]
+    public void MinMaxPickerDateTest()
+    {
+        var cut = Context.RenderComponent<CalendarMinMaxPickerDateTest>();
+        var comp = cut.FindComponent<MudCalendar<CalendarItem>>();
+        var picker = cut.FindComponent<MudDatePicker>();
+
+        // Check that the date picker's min date is 1/1/2024
+        picker.Instance.MinDate.Should().Be(new DateTime(2024, 1, 1));
+
+        // Check that the date picker's max date is 12/31/2026
+        picker.Instance.MaxDate.Should().Be(new DateTime(2026, 12, 31));
+    }
 }

--- a/Heron.MudCalendar/Components/MudCalendar.razor
+++ b/Heron.MudCalendar/Components/MudCalendar.razor
@@ -70,7 +70,7 @@
                     }
                     @if (ShowDatePicker)
                     {
-                        <CalendarDatePicker Culture="@Culture" @ref="_datePicker" OpenTo="@(View == CalendarView.Month ? OpenTo.Month : OpenTo.Date)" FirstDayOfWeek="@GetFirstDayOfWeekByCalendarView(View)" FixDay="@(View == CalendarView.Month ? 1 : null)" Date="PickerDate" DateChanged="DatePickerDateChanged" View="View" Variant="ButtonVariant" Color="Color" PickerOpened="OnDatePickerOpened"/>
+                        <CalendarDatePicker Culture="@Culture" @ref="_datePicker" OpenTo="@(View == CalendarView.Month ? OpenTo.Month : OpenTo.Date)" FirstDayOfWeek="@GetFirstDayOfWeekByCalendarView(View)" FixDay="@(View == CalendarView.Month ? 1 : null)" Date="PickerDate" DateChanged="DatePickerDateChanged" MinDate="PickerMinDate" MaxDate="PickerMaxDate" View="View" Variant="ButtonVariant" Color="Color" PickerOpened="OnDatePickerOpened"/>
                     }
                     @if (ShowTodayButton)
                     {

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -495,6 +495,26 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     }
 
     /// <summary>
+    /// Sets the date picker's minimum date.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Calendar.Behavior)]
+    public DateTime? PickerMinDate { get; set; }
+
+    /// <summary>
+    /// Sets the date picker's maximum date.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Calendar.Behavior)]
+    public DateTime? PickerMaxDate { get; set; }
+
+    /// <summary>
     /// The dates that are currently visible in the Calendar.
     /// </summary>
     public CalendarDateRange? CurrentDateRange { get; private set; }


### PR DESCRIPTION
### What changed
- Added PickerMinDate and PickerMaxDate parameters to the main MudCalendar component
- Forwarding new parameters to the underlying CalendarDatePicker
- Added test component with backing bunit test to verify new functionality

### Why
MudCalendar currently exposes a date picker for navigation, but currently does not allow consumers to constrain the selectable date range. This makes it difficult to prevent users from navigating to dates that are outside the valid bounds of the underlying data (e.g., historical limits, future scheduling restrictions, business rules).

Adding `PickerMinDate` and `PickerMaxDate` aligns MudCalendar's CalendarDatePicker more closely with the capabilities of `MudDatePicker`, avoids the need for custom wrappers or workarounds, and allows consumers to enforce valid date ranges declaratively.

### Notes
- No breaking changes
- Screenshot of new test UI attached


<img width="1914" height="908" alt="2026-01-06 22_44_22-MudCalendar UnitTest Component Viewer — Mozilla Firefox" src="https://github.com/user-attachments/assets/36fe4af9-314f-4af1-9b55-ff33e8e97633" />
