### PR TITLE
update webcompiler to 4.3.0

### DIFF
--- a/Heron.MudCalendar/.config/dotnet-tools.json
+++ b/Heron.MudCalendar/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "excubo.webcompiler": {
-      "version": "4.0.4",
+      "version": "4.3.0",
       "commands": [
         "webcompiler"
       ]


### PR DESCRIPTION
Current webcompiler version is 4.0.4 and has only support for net9.0.
If net9.0 is missing on the system builds will fail.

This updates the webcompiler to 4.3.0 which is latest and has net10.0 support.
