### PR TITLE
Update MudBlazor to 9.0.0

### DIFF
--- a/Heron.MudCalendar.UnitTests.Viewer/Heron.MudCalendar.UnitTests.Viewer.csproj
+++ b/Heron.MudCalendar.UnitTests.Viewer/Heron.MudCalendar.UnitTests.Viewer.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.1" PrivateAssets="all" />
-		<PackageReference Include="MudBlazor" Version="9.0.0-rc.1" />
+		<PackageReference Include="MudBlazor" Version="9.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Heron.MudCalendar.UnitTests.Viewer/Heron.MudCalendar.UnitTests.Viewer.csproj
+++ b/Heron.MudCalendar.UnitTests.Viewer/Heron.MudCalendar.UnitTests.Viewer.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.1" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.1" PrivateAssets="all" />
-		<PackageReference Include="MudBlazor" Version="9.0.0-preview.2" />
+		<PackageReference Include="MudBlazor" Version="9.0.0-rc.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Heron.MudCalendar.UnitTests/Heron.MudCalendar.UnitTests.csproj
+++ b/Heron.MudCalendar.UnitTests/Heron.MudCalendar.UnitTests.csproj
@@ -26,7 +26,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="MudBlazor" Version="9.0.0-rc.1" />
+		<PackageReference Include="MudBlazor" Version="9.0.0" />
 		<PackageReference Include="ReportGenerator" Version="5.5.1" />
 	</ItemGroup>
 	

--- a/Heron.MudCalendar.UnitTests/Heron.MudCalendar.UnitTests.csproj
+++ b/Heron.MudCalendar.UnitTests/Heron.MudCalendar.UnitTests.csproj
@@ -26,7 +26,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="MudBlazor" Version="9.0.0-preview.2" />
+		<PackageReference Include="MudBlazor" Version="9.0.0-rc.1" />
 		<PackageReference Include="ReportGenerator" Version="5.5.1" />
 	</ItemGroup>
 	

--- a/Heron.MudCalendar/Components/MonthView.razor.cs
+++ b/Heron.MudCalendar/Components/MonthView.razor.cs
@@ -113,7 +113,7 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         return new StyleBuilder()
             .AddStyle("border-right", "none",
                 (index + 1) % Columns == 0 && !(calendarCell.Today && Calendar.HighlightToday))
-            .AddStyle("border", $"1px solid var(--mud-palette-{Calendar.Color.ToDescriptionString()})",
+            .AddStyle("border", $"1px solid var(--mud-palette-{Calendar.Color.ToString().ToLowerInvariant()})",
                 calendarCell.Today && Calendar.HighlightToday)
             .AddStyle("width", $"{(100.0 / Columns).ToInvariantString()}%")
             .Build();

--- a/Heron.MudCalendar/Heron.MudCalendar.csproj
+++ b/Heron.MudCalendar/Heron.MudCalendar.csproj
@@ -81,7 +81,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MudBlazor" Version="9.0.0-rc.1" />
+        <PackageReference Include="MudBlazor" Version="9.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Heron.MudCalendar/Heron.MudCalendar.csproj
+++ b/Heron.MudCalendar/Heron.MudCalendar.csproj
@@ -81,7 +81,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MudBlazor" Version="9.0.0-preview.2" />
+        <PackageReference Include="MudBlazor" Version="9.0.0-rc.1" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
### What changed
- Updated all MudBlazor references from 9.0.0-preview.2 to 9.0.0

### Why
- Stay current with latest MudBlazor release candidate
- Resolve breaking changes in MudBlazor 9.0.0 related to Color.ToDescriptionString 

### Notes
- All unit tests pass
- Major version update - verify in demo app before merging