### PR TITLE
Several handy features

### DIFF
--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarWeekNumberTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarWeekNumberTest.razor
@@ -1,0 +1,23 @@
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudCalendar T="CalendarItem" Items="_events" ShowTodayButton="true" ShowWorkWeek="true" ShowWeekNumbers="true" />
+
+@code {
+    public static string __description__ = "Basic Calendar Tests";
+    
+    private List<CalendarItem> _events = new()
+    {
+        new CalendarItem
+        {
+            Start = DateTime.Today.AddHours(10),
+            End = DateTime.Today.AddHours(11),
+            Text = "Event today"
+        },
+        new CalendarItem
+        {
+            Start = DateTime.Today.AddDays(1).AddHours(11),
+            End = DateTime.Today.AddDays(1).AddHours(12.5),
+            Text = "Event tomorrow"
+        }
+    };
+}

--- a/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarWeekSummaryTest.razor
+++ b/Heron.MudCalendar.UnitTests.Viewer/TestComponents/Calendar/CalendarWeekSummaryTest.razor
@@ -1,0 +1,73 @@
+@using Heron.MudCalendar
+
+<MudPopoverProvider></MudPopoverProvider>
+
+<MudCalendar T="EmployeeItem" Items="_events" View="CalendarView.Month" ShowWeekNumbers="true"
+             MonthWeekSummaryTitle="Hours / week"
+             MonthWeekSummaryTemplate="@(_showSummary ? SummaryTemplate : null)" />
+
+<MudSwitch T="bool" @bind-Value="_showSummary" Color="Color.Primary" Label="Show week summary" />
+
+@code {
+    public static string __description__ = "Month view per-week summary column";
+
+    private bool _showSummary = true;
+
+    private RenderFragment<CalendarWeekSummary<EmployeeItem>> SummaryTemplate => week =>
+        @<text>
+            @foreach (var employee in HoursPerEmployee(week))
+            {
+                <div class="mud-cal-week-summary-row">
+                    <span>@employee.Key</span>
+                    <span>@employee.Value.ToString("0.#")h</span>
+                </div>
+            }
+        </text>;
+
+    public class EmployeeItem : CalendarItem
+    {
+        public string Employee { get; set; } = string.Empty;
+    }
+
+    private static IEnumerable<KeyValuePair<string, double>> HoursPerEmployee(CalendarWeekSummary<EmployeeItem> week)
+    {
+        return week.Items
+            .GroupBy(i => i.Employee)
+            .Select(g => new KeyValuePair<string, double>(
+                g.Key,
+                g.Sum(i => ((i.End ?? i.Start.AddHours(1)) - i.Start).TotalHours)))
+            .OrderBy(e => e.Key);
+    }
+
+    private readonly List<EmployeeItem> _events = new()
+    {
+        new EmployeeItem
+        {
+            Start = DateTime.Today.AddHours(9),
+            End = DateTime.Today.AddHours(17),
+            Text = "Shift",
+            Employee = "Alice"
+        },
+        new EmployeeItem
+        {
+            Start = DateTime.Today.AddDays(1).AddHours(8),
+            End = DateTime.Today.AddDays(1).AddHours(12),
+            Text = "Shift",
+            Employee = "Bob"
+        },
+        new EmployeeItem
+        {
+            Start = DateTime.Today.AddDays(2).AddHours(13),
+            End = DateTime.Today.AddDays(2).AddHours(17),
+            Text = "Shift",
+            Employee = "Alice"
+        },
+        new EmployeeItem
+        {
+            Start = DateTime.Today.AddDays(8).AddHours(9),
+            End = DateTime.Today.AddDays(8).AddHours(15),
+            Text = "Shift",
+            Employee = "Bob"
+        }
+    };
+}

--- a/Heron.MudCalendar/Components/CalendarDateRange.cs
+++ b/Heron.MudCalendar/Components/CalendarDateRange.cs
@@ -106,4 +106,10 @@ public class CalendarDateRange : DateRange
 
         return day;
     }
+
+    public static int GetWeekNumber(DateTime date, CultureInfo culture, DayOfWeek? firstDayOfWeek = null)
+    {
+        var firstDay = firstDayOfWeek ?? culture.DateTimeFormat.FirstDayOfWeek;
+        return culture.Calendar.GetWeekOfYear(date, CalendarWeekRule.FirstDay, firstDay);
+    }
 }

--- a/Heron.MudCalendar/Components/CalendarWeekSummary.cs
+++ b/Heron.MudCalendar/Components/CalendarWeekSummary.cs
@@ -1,0 +1,30 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Heron.MudCalendar;
+
+/// <summary>
+/// Context passed to <see cref="MudCalendar{T}.MonthWeekSummaryTemplate"/> for each week (row) of the month view.
+/// </summary>
+/// <typeparam name="T">The type of item displayed in the calendar.</typeparam>
+public class CalendarWeekSummary<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)] T> where T : CalendarItem
+{
+    /// <summary>
+    /// The week number of the displayed week.
+    /// </summary>
+    public int WeekNumber { get; set; }
+
+    /// <summary>
+    /// The first day shown in the week row.
+    /// </summary>
+    public DateTime WeekStart { get; set; }
+
+    /// <summary>
+    /// The last day shown in the week row.
+    /// </summary>
+    public DateTime WeekEnd { get; set; }
+
+    /// <summary>
+    /// All items that overlap the displayed week row, including multi-day items spanning into the week.
+    /// </summary>
+    public IReadOnlyList<T> Items { get; set; } = new List<T>();
+}

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -39,14 +39,26 @@
     /// Renders the header of the grid.
     /// </summary>
     protected virtual RenderFragment RenderHeader =>
-        @<div class="mud-cal-grid-header mud-cal-month-grid-header" style="@GridStyle">
-            @for (var i = 0; i < Columns; i++)
-            {
-                <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">
-                    @RenderDayTitle(i)
+        Calendar.ShowWeekNumbers
+            ? @<div class="mud-cal-month-header-row">
+                <div class="mud-cal-week-number-header" aria-hidden="true"></div>
+                <div class="mud-cal-grid-header mud-cal-month-grid-header" style="@GridStyle">
+                    @for (var i = 0; i < Columns; i++)
+                    {
+                        <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">
+                            @RenderDayTitle(i)
+                        </div>
+                    }
                 </div>
-            }
-        </div>;
+            </div>
+            : @<div class="mud-cal-grid-header mud-cal-month-grid-header" style="@GridStyle">
+                @for (var i = 0; i < Columns; i++)
+                {
+                    <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">
+                        @RenderDayTitle(i)
+                    </div>
+                }
+            </div>;
 
     /// <summary>
     /// Renders the day name.
@@ -68,49 +80,73 @@
     {
         for (var row = 0; row < Rows; row++)
         {
-            <div class="mud-cal-month-row-holder" style="@RowStyle">
-                @for (var cell = row * Columns; cell < (row * Columns) + Columns; cell++)
+            if (Calendar.ShowWeekNumbers)
+            {
+                var weekNumber = GetWeekNumberForRow(row);
+                <div class="mud-cal-month-row-holder" style="@RowStyle">
+                    <div class="mud-cal-week-number" aria-label="@($"Week {weekNumber}")">
+                        @weekNumber
+                    </div>
+                    <div class="mud-cal-month-row-content">
+                        @RenderRowCells(row)
+                        @RenderCellContents(row)
+                    </div>
+                </div>
+            }
+            else
+            {
+                <div class="mud-cal-month-row-holder" style="@RowStyle">
+                    @RenderRowCells(row)
+                    @RenderCellContents(row)
+                </div>
+            }
+        }
+    };
+
+    /// <summary>
+    /// Renders the day cells for a row.
+    /// </summary>
+    protected virtual RenderFragment RenderRowCells(int row) => __builder =>
+    {
+        for (var cell = row * Columns; cell < (row * Columns) + Columns; cell++)
+        {
+            var currentCell = Cells[cell];
+            <MudDropZone T="T" OnlyZone="true" Identifier="@currentCell.Date.Date.ToString("d")"
+                         Class="@CellClassname(currentCell)" Style="@DayStyle(currentCell, cell)"
+                         CanDrop="@(item => Calendar.CanDropItem == null || Calendar.CanDropItem(item, currentCell.Date, CalendarView.Month))">
+                @if (AllowCellLinkClick(currentCell) && AllowCellLinkContextMenuClick(currentCell))
                 {
-                    var currentCell = Cells[cell];
-                    <MudDropZone T="T" OnlyZone="true" Identifier="@currentCell.Date.Date.ToString("d")"
-                                 Class="@CellClassname(currentCell)" Style="@DayStyle(currentCell, cell)"
-                                 CanDrop="@(item => Calendar.CanDropItem == null || Calendar.CanDropItem(item, currentCell.Date, CalendarView.Month))">
-                        @if (AllowCellLinkClick(currentCell) && AllowCellLinkContextMenuClick(currentCell))
-                        {
-                            <a @onclick="() => OnCellLinkClicked(currentCell)"
-                               @oncontextmenu="@(mouseEventArgs => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell))" @oncontextmenu:preventDefault
-                               class="mud-cal-month-cell-link">
-                                <div class="@CellLinkClassname(false)" data-date="@currentCell.Date.ToString("yyyy-MM-dd")" data-row="0" data-selectable="@IsSelectable(currentCell).ToString().ToLower()">
-                                    @RenderCellDayNumber(currentCell)
-                                </div>
-                            </a>
-                        }
-                        else if (AllowCellLinkContextMenuClick(currentCell))
-                        {
-                            <a @oncontextmenu="@(mouseEventArgs => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell))" @oncontextmenu:preventDefault
-                               class="mud-cal-month-cell-link">
-                                <div class="@CellLinkClassname(true)">
-                                    @RenderCellDayNumber(currentCell)
-                                </div>
-                            </a>
-                        }
-                        else if (AllowCellLinkClick(currentCell))
-                        {
-                            <a @onclick="() => OnCellLinkClicked(currentCell)"
-                               class="mud-cal-month-cell-link">
-                                <div class="@CellLinkClassname(false)" data-date="@currentCell.Date.ToString("yyyy-MM-dd")" data-row="0" data-selectable="@IsSelectable(currentCell).ToString().ToLower()">
-                                    @RenderCellDayNumber(currentCell)
-                                </div>
-                            </a>
-                        }
-                        else
-                        {
+                    <a @onclick="() => OnCellLinkClicked(currentCell)"
+                       @oncontextmenu="@(mouseEventArgs => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell))" @oncontextmenu:preventDefault
+                       class="mud-cal-month-cell-link">
+                        <div class="@CellLinkClassname(false)" data-date="@currentCell.Date.ToString("yyyy-MM-dd")" data-row="0" data-selectable="@IsSelectable(currentCell).ToString().ToLower()">
                             @RenderCellDayNumber(currentCell)
-                        }
-                    </MudDropZone>
+                        </div>
+                    </a>
                 }
-                @RenderCellContents(row)
-            </div>
+                else if (AllowCellLinkContextMenuClick(currentCell))
+                {
+                    <a @oncontextmenu="@(mouseEventArgs => OnCellLinkContextMenuClicked(mouseEventArgs, currentCell))" @oncontextmenu:preventDefault
+                       class="mud-cal-month-cell-link">
+                        <div class="@CellLinkClassname(true)">
+                            @RenderCellDayNumber(currentCell)
+                        </div>
+                    </a>
+                }
+                else if (AllowCellLinkClick(currentCell))
+                {
+                    <a @onclick="() => OnCellLinkClicked(currentCell)"
+                       class="mud-cal-month-cell-link">
+                        <div class="@CellLinkClassname(false)" data-date="@currentCell.Date.ToString("yyyy-MM-dd")" data-row="0" data-selectable="@IsSelectable(currentCell).ToString().ToLower()">
+                            @RenderCellDayNumber(currentCell)
+                        </div>
+                    </a>
+                }
+                else
+                {
+                    @RenderCellDayNumber(currentCell)
+                }
+            </MudDropZone>
         }
     };
 

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -45,7 +45,7 @@
                 {
                     <div class="mud-cal-week-number-header" aria-hidden="true"></div>
                 }
-                <div class="mud-cal-grid-header mud-cal-month-grid-header @(ShowWeekSummary ? "mud-cal-month-grid-header--with-summary" : null)" style="@HeaderGridStyle">
+                <div class="mud-cal-grid-header mud-cal-month-grid-header" style="@HeaderGridStyle">
                     @for (var i = 0; i < Columns; i++)
                     {
                         <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">
@@ -104,7 +104,7 @@
                         @weekNumber
                     </div>
                 }
-                <div class="mud-cal-month-row-content @(ShowWeekSummary ? "mud-cal-month-row-content--with-summary" : null)">
+                <div class="mud-cal-month-row-content">
                     @RenderRowCells(row)
                     @RenderCellContents(row)
                 </div>

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -80,26 +80,19 @@
     {
         for (var row = 0; row < Rows; row++)
         {
-            if (Calendar.ShowWeekNumbers)
-            {
-                var weekNumber = GetWeekNumberForRow(row);
-                <div class="mud-cal-month-row-holder" style="@RowStyle">
+            var weekNumber = Calendar.ShowWeekNumbers ? GetWeekNumberForRow(row) : 0;
+            <div class="mud-cal-month-row-holder" style="@RowStyle">
+                @if (Calendar.ShowWeekNumbers)
+                {
                     <div class="mud-cal-week-number" aria-label="@($"Week {weekNumber}")">
                         @weekNumber
                     </div>
-                    <div class="mud-cal-month-row-content">
-                        @RenderRowCells(row)
-                        @RenderCellContents(row)
-                    </div>
-                </div>
-            }
-            else
-            {
-                <div class="mud-cal-month-row-holder" style="@RowStyle">
+                }
+                <div class="mud-cal-month-row-content">
                     @RenderRowCells(row)
                     @RenderCellContents(row)
                 </div>
-            }
+            </div>
         }
     };
 

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -39,10 +39,13 @@
     /// Renders the header of the grid.
     /// </summary>
     protected virtual RenderFragment RenderHeader =>
-        Calendar.ShowWeekNumbers
+        Calendar.ShowWeekNumbers || ShowWeekSummary
             ? @<div class="mud-cal-month-header-row">
-                <div class="mud-cal-week-number-header" aria-hidden="true"></div>
-                <div class="mud-cal-grid-header mud-cal-month-grid-header" style="@HeaderGridStyle">
+                @if (Calendar.ShowWeekNumbers)
+                {
+                    <div class="mud-cal-week-number-header" aria-hidden="true"></div>
+                }
+                <div class="mud-cal-grid-header mud-cal-month-grid-header @(ShowWeekSummary ? "mud-cal-month-grid-header--with-summary" : null)" style="@HeaderGridStyle">
                     @for (var i = 0; i < Columns; i++)
                     {
                         <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">
@@ -50,6 +53,19 @@
                         </div>
                     }
                 </div>
+                @if (ShowWeekSummary)
+                {
+                    <div class="mud-cal-week-summary-header">
+                        @if (Calendar.MonthWeekSummaryHeaderTemplate != null)
+                        {
+                            @Calendar.MonthWeekSummaryHeaderTemplate
+                        }
+                        else if (!string.IsNullOrEmpty(Calendar.MonthWeekSummaryTitle))
+                        {
+                            <div class="mud-cal-week-summary-title">@Calendar.MonthWeekSummaryTitle</div>
+                        }
+                    </div>
+                }
             </div>
             : @<div class="mud-cal-grid-header mud-cal-month-grid-header" style="@HeaderGridStyle">
                 @for (var i = 0; i < Columns; i++)
@@ -88,10 +104,16 @@
                         @weekNumber
                     </div>
                 }
-                <div class="mud-cal-month-row-content">
+                <div class="mud-cal-month-row-content @(ShowWeekSummary ? "mud-cal-month-row-content--with-summary" : null)">
                     @RenderRowCells(row)
                     @RenderCellContents(row)
                 </div>
+                @if (ShowWeekSummary)
+                {
+                    <div class="mud-cal-week-summary">
+                        @Calendar.MonthWeekSummaryTemplate!(BuildWeekSummary(row))
+                    </div>
+                }
             </div>
         }
     };

--- a/Heron.MudCalendar/Components/MonthView.razor
+++ b/Heron.MudCalendar/Components/MonthView.razor
@@ -42,7 +42,7 @@
         Calendar.ShowWeekNumbers
             ? @<div class="mud-cal-month-header-row">
                 <div class="mud-cal-week-number-header" aria-hidden="true"></div>
-                <div class="mud-cal-grid-header mud-cal-month-grid-header" style="@GridStyle">
+                <div class="mud-cal-grid-header mud-cal-month-grid-header" style="@HeaderGridStyle">
                     @for (var i = 0; i < Columns; i++)
                     {
                         <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">
@@ -51,7 +51,7 @@
                     }
                 </div>
             </div>
-            : @<div class="mud-cal-grid-header mud-cal-month-grid-header" style="@GridStyle">
+            : @<div class="mud-cal-grid-header mud-cal-month-grid-header" style="@HeaderGridStyle">
                 @for (var i = 0; i < Columns; i++)
                 {
                     <div class="mud-cal-month-header" aria-label="@Cells[i].Date.ToString("dddd")">

--- a/Heron.MudCalendar/Components/MonthView.razor.cs
+++ b/Heron.MudCalendar/Components/MonthView.razor.cs
@@ -137,6 +137,31 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
             .Build();
 
     /// <summary>
+    /// Gets the week number for the given date.
+    /// </summary>
+    protected virtual int GetWeekNumber(DateTime date) =>
+        CalendarDateRange.GetWeekNumber(date, Calendar.Culture, Calendar.FirstDayOfWeek);
+
+    /// <summary>
+    /// Gets the week number for a month view row, using the first day of the displayed month in that row.
+    /// </summary>
+    protected virtual int GetWeekNumberForRow(int row)
+    {
+        var rowStart = row * Columns;
+        var rowEnd = rowStart + Columns;
+
+        for (var i = rowStart; i < rowEnd; i++)
+        {
+            if (!Cells[i].Outside)
+            {
+                return GetWeekNumber(Cells[i].Date);
+            }
+        }
+
+        return GetWeekNumber(Cells[rowStart].Date);
+    }
+
+    /// <summary>
     /// Method invoked when the user clicks on the hyperlink in the cell.
     /// </summary>
     /// <param name="cell">The cell that was clicked.</param>

--- a/Heron.MudCalendar/Components/MonthView.razor.cs
+++ b/Heron.MudCalendar/Components/MonthView.razor.cs
@@ -38,6 +38,7 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
         new CssBuilder("mud-cal-month-table-body")
             .AddClass("mud-cal-month-layer")
             .AddClass("mud-cal-month-fixed-height", Calendar.MonthCellMinHeight == 0)
+            .AddClass("mud-cal-month-scrollable", Calendar.MonthCellMinHeight > 0)
             .AddClass("mud-cal-selectable-container", Calendar.CellRangeSelected.HasDelegate)
             .Build();
 
@@ -130,6 +131,7 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
 
     protected virtual string RowStyle =>
         new StyleBuilder()
+            .AddStyle("height", Calendar.MonthCellMinHeight + "px", Calendar.MonthCellMinHeight > 0)
             .AddStyle("min-height", Calendar.MonthCellMinHeight + "px", Calendar.MonthCellMinHeight > 0)
             .Build();
 

--- a/Heron.MudCalendar/Components/MonthView.razor.cs
+++ b/Heron.MudCalendar/Components/MonthView.razor.cs
@@ -32,6 +32,35 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
     protected virtual int Rows => Cells.Count / Columns;
 
     /// <summary>
+    /// Whether the per-week summary column should be shown.
+    /// </summary>
+    protected bool ShowWeekSummary => Calendar.MonthWeekSummaryTemplate != null;
+
+    /// <summary>
+    /// Builds the summary context for a month view row (week).
+    /// </summary>
+    /// <param name="row">The row index.</param>
+    protected virtual CalendarWeekSummary<T> BuildWeekSummary(int row)
+    {
+        var weekStart = Cells[row * Columns].Date.Date;
+        var weekEnd = Cells[(row * Columns) + Columns - 1].Date.Date;
+        var rangeEnd = weekEnd.AddDays(1).AddTicks(-1);
+
+        var items = Calendar.Items
+            .Where(i => i.Start <= rangeEnd && (i.End ?? i.Start) >= weekStart)
+            .OrderBy(i => i.Start)
+            .ToList();
+
+        return new CalendarWeekSummary<T>
+        {
+            WeekNumber = GetWeekNumberForRow(row),
+            WeekStart = weekStart,
+            WeekEnd = weekEnd,
+            Items = items
+        };
+    }
+
+    /// <summary>
     /// Classes added to main div of the component.
     /// </summary>
     protected virtual string Classname =>

--- a/Heron.MudCalendar/Components/MonthView.razor.cs
+++ b/Heron.MudCalendar/Components/MonthView.razor.cs
@@ -42,14 +42,11 @@ public partial class MonthView<[DynamicallyAccessedMembers(DynamicallyAccessedMe
             .Build();
 
     /// <summary>
-    /// Styles added to the main grid.
+    /// Styles added to the month view header.
     /// </summary>
-    protected virtual string GridStyle =>
+    protected virtual string HeaderGridStyle =>
         new StyleBuilder()
             .AddStyle("grid-template-columns", $"repeat({Columns}, minmax(10px, 1fr))")
-            .AddStyle("grid-template-rows",
-                $"repeat({Rows}, {(100.0 / Rows).ToInvariantString()}%)",
-                Calendar.MonthCellMinHeight == 0)
             .Build();
 
     /// <summary>

--- a/Heron.MudCalendar/Components/MudCalendar.razor
+++ b/Heron.MudCalendar/Components/MudCalendar.razor
@@ -65,8 +65,14 @@
                 <div class="mud-cal-toolbar-nav align-center">
                     @if (ShowPrevNextButtons)
                     {
-                            <MudIconButton Variant="@ButtonVariant" Icon="@Icons.Material.Outlined.ChevronLeft" aria-label="@PrevAriaLabel" Color="@Color" OnClick="@OnPreviousClicked" Disabled="@_prevButtonDisabled"/>
-                            <MudIconButton Variant="@ButtonVariant" Icon="@Icons.Material.Outlined.ChevronRight" aria-label="@NextAriaLabel" Color="@Color" OnClick="@OnNextClicked" Disabled="@_nextButtonDisabled"/>
+                        <MudHidden Breakpoint="Breakpoint.MdAndDown">
+                            <MudIconButton Variant="@ButtonVariant" Icon="@Icons.Material.Outlined.ChevronLeft"
+                                           aria-label="@PrevAriaLabel" Color="@Color" OnClick="@OnPreviousClicked"
+                                           Disabled="@_prevButtonDisabled"/>
+                            <MudIconButton Variant="@ButtonVariant" Icon="@Icons.Material.Outlined.ChevronRight"
+                                           aria-label="@NextAriaLabel" Color="@Color" OnClick="@OnNextClicked"
+                                           Disabled="@_nextButtonDisabled"/>
+                        </MudHidden>
                     }
                     @if (ShowDatePicker)
                     {
@@ -90,7 +96,13 @@
                     }
                     else
                     {
-                        <EnumSwitch Value="@View" T="CalendarView" Color="@Color" AllowedValues="AllowedViews()" ValueChanged="OnViewChanging"/>
+                        <MudHidden Breakpoint="Breakpoint.MdAndDown">
+                            <EnumSwitch Value="@View" T="CalendarView" Color="@Color" AllowedValues="AllowedViews()" ValueChanged="OnViewChanging"/>
+                        </MudHidden>
+                        
+                        <MudHidden Breakpoint="Breakpoint.MdAndDown" Invert="true">
+                            <EnumMenu Value="@View" T="CalendarView" Color="@Color" Variant="ButtonVariant" AllowedValues="AllowedViews()" ValueChanged="OnViewChanging"/>
+                        </MudHidden>
                     }
                 </div>
             </div>;

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Reflection;
 using Heron.MudCalendar.Services;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Localization;
@@ -9,7 +10,6 @@ using MudBlazor;
 using CategoryAttribute = Heron.MudCalendar.Attributes.CategoryAttribute;
 using CategoryTypes = Heron.MudCalendar.Attributes.CategoryTypes;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 
 namespace Heron.MudCalendar;
 
@@ -826,7 +826,8 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
 
         // Add the link
         _jsService.OnLinkLoaded += (_, _) => Refresh();
-        await _jsService.AddLink("_content/Heron.MudCalendar/Heron.MudCalendar.min.css", "stylesheet");
+        var version = typeof(MudCalendar<>).Assembly.GetName().Version?.ToString() ?? "1.0.0";
+        await _jsService.AddLink($"_content/Heron.MudCalendar/Heron.MudCalendar.min.css?v={version}", "stylesheet");
     }
 
     private async Task DatePickerDateChanged(DateTime? dateTime)

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -448,6 +448,39 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     public RenderFragment<T>? MonthTemplate { get; set; }
     
     /// <summary>
+    /// Defines the content of an optional per-week summary column shown on the right of the Month view.
+    /// The column is shown only when this template is set.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Category(CategoryTypes.Calendar.Template)]
+    [Parameter]
+    public RenderFragment<CalendarWeekSummary<T>>? MonthWeekSummaryTemplate { get; set; }
+
+    /// <summary>
+    /// The title shown in the header cell above the Month view week summary column.
+    /// Ignored when <see cref="MonthWeekSummaryHeaderTemplate"/> is set.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Category(CategoryTypes.Calendar.Template)]
+    [Parameter]
+    public string? MonthWeekSummaryTitle { get; set; }
+
+    /// <summary>
+    /// Defines the content of the header cell above the Month view week summary column.
+    /// Overrides <see cref="MonthWeekSummaryTitle"/> when set.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>null</c>.
+    /// </remarks>
+    [Category(CategoryTypes.Calendar.Template)]
+    [Parameter]
+    public RenderFragment? MonthWeekSummaryHeaderTemplate { get; set; }
+
+    /// <summary>
     /// Defines the cell content for the Week view.
     /// </summary>
     /// <remarks>

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -77,7 +77,7 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// </remarks>
     [Parameter]
     [Category(CategoryTypes.Calendar.Appearance)]
-    public int Height { get; set; } = 700;
+    public string Height { get; set; } = "700px";
 
     /// <summary>
     /// Gets or sets the minimum height of a cell.
@@ -620,8 +620,8 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// Styles added to main div of the component.
     /// </summary>
     protected virtual string Styles =>
-        new StyleBuilder("min-height", $"{Height}px")
-            .AddStyle("height", $"{Height}px", View == CalendarView.Month && MonthCellMinHeight > 0)
+        new StyleBuilder("min-height", Height)
+            .AddStyle("height", Height, View == CalendarView.Month && MonthCellMinHeight > 0)
             .AddStyle(Style)
             .Build();
 

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -588,6 +588,7 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     /// </summary>
     protected virtual string Styles =>
         new StyleBuilder("min-height", $"{Height}px")
+            .AddStyle("height", $"{Height}px", View == CalendarView.Month && MonthCellMinHeight > 0)
             .AddStyle(Style)
             .Build();
 

--- a/Heron.MudCalendar/Components/MudCalendar.razor.cs
+++ b/Heron.MudCalendar/Components/MudCalendar.razor.cs
@@ -88,6 +88,16 @@ public partial class MudCalendar<[DynamicallyAccessedMembers(DynamicallyAccessed
     [Parameter]
     [Category(CategoryTypes.Calendar.Appearance)]
     public int MonthCellMinHeight { get; set; }
+
+    /// <summary>
+    /// If true, shows a column with week numbers on the left of the month view.
+    /// </summary>
+    /// <remarks>
+    /// Defaults to <c>false</c>.
+    /// </remarks>
+    [Parameter]
+    [Category(CategoryTypes.Calendar.Appearance)]
+    public bool ShowWeekNumbers { get; set; }
     
     /// <summary>
     /// Gets or sets the day that the calendar is showing.

--- a/Heron.MudCalendar/Heron.MudCalendar.csproj
+++ b/Heron.MudCalendar/Heron.MudCalendar.csproj
@@ -4,7 +4,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <Version>1.0.1</Version>
+        <Version>1.0.6</Version>
     </PropertyGroup>
     
     <PropertyGroup>

--- a/Heron.MudCalendar/Heron.MudCalendar.csproj
+++ b/Heron.MudCalendar/Heron.MudCalendar.csproj
@@ -4,6 +4,7 @@
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
         <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+        <Version>1.0.1</Version>
     </PropertyGroup>
     
     <PropertyGroup>

--- a/Heron.MudCalendar/Scripts/ItemPositioner.js
+++ b/Heron.MudCalendar/Scripts/ItemPositioner.js
@@ -14,18 +14,20 @@ export function positionMonthItems(element, moreText, fixedHeight, obj) {
         
         element.querySelectorAll(".mud-cal-month-row-holder").forEach(function(container) {
             try {
+                const contentContainer = container.querySelector(".mud-cal-month-row-content") || container;
+
                 // Remove any existing messages
-                container.querySelectorAll(".mud-cal-overflow-message").forEach(function (message) {
+                contentContainer.querySelectorAll(".mud-cal-overflow-message").forEach(function (message) {
                     message.remove();
                 });
 
                 // Find the height of the header part
                 const datePositions = new Map();
-                const totalWidth = container.clientWidth;
-                const cellCount = container.querySelectorAll(".mud-cal-month-cell").length;
+                const totalWidth = contentContainer.clientWidth;
+                const cellCount = contentContainer.querySelectorAll(".mud-cal-month-cell").length;
                 let headerHeight = 0;
                 let index = 0;
-                container.querySelectorAll(".mud-cal-month-cell").forEach(function(cell) {
+                contentContainer.querySelectorAll(".mud-cal-month-cell").forEach(function(cell) {
                     let height = 0;
                     cell.querySelectorAll(".mud-cal-month-cell-header").forEach(function(item) {
                         height += item.clientHeight;
@@ -38,7 +40,7 @@ export function positionMonthItems(element, moreText, fixedHeight, obj) {
                 
                 const positions = [];
                 const overlaps = [];
-                container.querySelectorAll(".mud-cal-drop-item").forEach(function(item) {
+                contentContainer.querySelectorAll(".mud-cal-drop-item").forEach(function(item) {
                     // Remove any overflow messages
                     item.classList.remove("mud-cal-overflow-hidden");
 
@@ -84,7 +86,7 @@ export function positionMonthItems(element, moreText, fixedHeight, obj) {
                         if (!starts.includes(position.Start)) starts.push(position.Start);
                     });
                     starts.forEach((start) => {
-                        hideOverflows(container, positions.filter(p => p.Start === start), start, datePositions);
+                        hideOverflows(contentContainer, positions.filter(p => p.Start === start), start, datePositions);
                     });
                 }
                 else

--- a/Heron.MudCalendar/Scripts/ItemPositioner.js
+++ b/Heron.MudCalendar/Scripts/ItemPositioner.js
@@ -91,11 +91,13 @@ export function positionMonthItems(element, moreText, fixedHeight, obj) {
                 }
                 else
                 {
-                    // Calculate the height of the row
+                    // Grow the row to fit all of its items. When MonthCellMinHeight is set
+                    // the row keeps at least that height (via CSS min-height) and the whole
+                    // month body scrolls within the viewport.
                     let rowMaxBottom = headerHeight;
                     positions.forEach((position) => {
                         if (position.Bottom > rowMaxBottom) rowMaxBottom = position.Bottom;
-                    })
+                    });
                     container.style.height = rowMaxBottom + "px";
                 }
                 

--- a/Heron.MudCalendar/Services/JsService.cs
+++ b/Heron.MudCalendar/Services/JsService.cs
@@ -8,7 +8,7 @@ public class JsService : IAsyncDisposable
     private readonly Lazy<Task<IJSObjectReference>> _moduleTask;
     private readonly CancellationTokenSource _cancellationTokenSource = new();
     private DotNetObjectReference<JsService>? _this;
-    
+
     private IJSObjectReference? _multiSelect;
 
     public event EventHandler? OnLinkLoaded;
@@ -19,8 +19,14 @@ public class JsService : IAsyncDisposable
 
     public JsService(IJSRuntime jsRuntime)
     {
+        var version = typeof(JsService).Assembly
+            .GetCustomAttributes(typeof(System.Reflection.AssemblyInformationalVersionAttribute), false)
+            .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
+            .FirstOrDefault()?.InformationalVersion ?? "1.0.0";
+
         _moduleTask = new Lazy<Task<IJSObjectReference>>(() => jsRuntime.InvokeAsync<IJSObjectReference>(
-            "import", _cancellationTokenSource.Token, "./_content/Heron.MudCalendar/Heron.MudCalendar.min.js").AsTask());
+            "import", _cancellationTokenSource.Token,
+            $"./_content/Heron.MudCalendar/Heron.MudCalendar.min.js?v={version}").AsTask());
     }
 
     public async Task Scroll(ElementReference element, int top)
@@ -28,7 +34,7 @@ public class JsService : IAsyncDisposable
         var module = await _moduleTask.Value;
         await module.InvokeVoidAsync("scroll", element, top);
     }
-    
+
     public async Task<string> GetHeadContent()
     {
         var module = await _moduleTask.Value;
@@ -41,7 +47,7 @@ public class JsService : IAsyncDisposable
         {
             _this ??= DotNetObjectReference.Create(this);
         }
-        
+
         var module = await _moduleTask.Value;
         await module.InvokeVoidAsync("addLink", href, rel, _this);
     }
@@ -51,7 +57,7 @@ public class JsService : IAsyncDisposable
     {
         OnLinkLoaded?.Invoke(this, EventArgs.Empty);
     }
-    
+
     public async Task AddDragHandler(string id, int width)
     {
         var module = await _moduleTask.Value;
@@ -64,7 +70,7 @@ public class JsService : IAsyncDisposable
         {
             _this ??= DotNetObjectReference.Create(this);
         }
-        
+
         var module = await _moduleTask.Value;
         await module.InvokeVoidAsync("positionMonthItems", element, moreText, fixedHeight, _this);
     }
@@ -101,7 +107,7 @@ public class JsService : IAsyncDisposable
     public async ValueTask DisposeAsync()
     {
         GC.SuppressFinalize(this);
-        
+
         if (_this != null) await CastAndDispose(_this);
         if (_multiSelect != null)
         {
@@ -118,10 +124,10 @@ public class JsService : IAsyncDisposable
         {
             // ignore
         }
-            
+
         try
         {
-            var module = await _moduleTask.Value; 
+            var module = await _moduleTask.Value;
             await module.DisposeAsync();
         }
         catch (OperationCanceledException)

--- a/Heron.MudCalendar/Styles/_monthView.scss
+++ b/Heron.MudCalendar/Styles/_monthView.scss
@@ -73,10 +73,6 @@
   overflow-y: auto;
 }
 
-.mud-cal-month-header-row .mud-cal-month-grid-header.mud-cal-month-grid-header--with-summary {
-  flex: 7 1 0;
-}
-
 .mud-cal-month-row-content {
   position: relative;
   display: flex;
@@ -84,10 +80,6 @@
   flex: 1;
   min-width: 0;
   height: 100%;
-
-  &.mud-cal-month-row-content--with-summary {
-    flex: 7 1 0;
-  }
 }
 
 .mud-cal-month-layer {

--- a/Heron.MudCalendar/Styles/_monthView.scss
+++ b/Heron.MudCalendar/Styles/_monthView.scss
@@ -115,3 +115,14 @@
   flex-direction: column;
   height: 100%;
 }
+
+.mud-cal-month-scrollable {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  .mud-cal-grid {
+    height: auto;
+  }
+}

--- a/Heron.MudCalendar/Styles/_monthView.scss
+++ b/Heron.MudCalendar/Styles/_monthView.scss
@@ -45,6 +45,38 @@
   border-top: 1px solid var(--mud-palette-table-lines);
 }
 
+.mud-cal-week-summary-header {
+  flex: 1 1 0;
+  min-width: 0;
+  background-color: var(--mud-palette-surface);
+
+  .mud-cal-week-summary-title {
+    text-align: center;
+    font-weight: 500;
+    line-height: 1.5rem;
+  }
+}
+
+.mud-cal-week-summary {
+  flex: 1 1 0;
+  min-width: 0;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  padding: 8px;
+  font-size: 0.75rem;
+  color: var(--mud-palette-text-secondary);
+  background-color: var(--mud-palette-background-gray);
+  border-left: 1px solid var(--mud-palette-table-lines);
+  border-top: 1px solid var(--mud-palette-table-lines);
+  overflow-y: auto;
+}
+
+.mud-cal-month-header-row .mud-cal-month-grid-header.mud-cal-month-grid-header--with-summary {
+  flex: 7 1 0;
+}
+
 .mud-cal-month-row-content {
   position: relative;
   display: flex;
@@ -52,6 +84,10 @@
   flex: 1;
   min-width: 0;
   height: 100%;
+
+  &.mud-cal-month-row-content--with-summary {
+    flex: 7 1 0;
+  }
 }
 
 .mud-cal-month-layer {

--- a/Heron.MudCalendar/Styles/_monthView.scss
+++ b/Heron.MudCalendar/Styles/_monthView.scss
@@ -46,24 +46,25 @@
 }
 
 .mud-cal-week-summary-header {
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 0 0 auto;
+  width: max-content;
   background-color: var(--mud-palette-surface);
 
   .mud-cal-week-summary-title {
     text-align: center;
     font-weight: 500;
     line-height: 1.5rem;
+    white-space: nowrap;
   }
 }
 
 .mud-cal-week-summary {
-  flex: 1 1 0;
-  min-width: 0;
+  flex: 0 0 auto;
+  width: max-content;
   height: 100%;
   display: flex;
   flex-direction: column;
-  align-items: stretch;
+  align-items: flex-start;
   padding: 8px;
   font-size: 0.75rem;
   color: var(--mud-palette-text-secondary);

--- a/Heron.MudCalendar/Styles/_monthView.scss
+++ b/Heron.MudCalendar/Styles/_monthView.scss
@@ -5,6 +5,12 @@
 .mud-cal-month-header-row {
   display: flex;
   flex-direction: row;
+  flex-shrink: 0;
+
+  .mud-cal-month-grid-header {
+    flex: 1;
+    min-width: 0;
+  }
 }
 
 .mud-cal-week-number-header {
@@ -15,8 +21,7 @@
 }
 
 .mud-cal-month-grid-header {
-  flex: 1;
-  min-width: 0;
+  flex-shrink: 0;
 
   .mud-cal-month-header {
     border-right: none;

--- a/Heron.MudCalendar/Styles/_monthView.scss
+++ b/Heron.MudCalendar/Styles/_monthView.scss
@@ -2,10 +2,51 @@
   height: 100%;
 }
 
+.mud-cal-month-header-row {
+  display: flex;
+  flex-direction: row;
+}
+
+.mud-cal-week-number-header {
+  width: 32px;
+  min-width: 32px;
+  flex-shrink: 0;
+  background-color: var(--mud-palette-surface);
+}
+
 .mud-cal-month-grid-header {
+  flex: 1;
+  min-width: 0;
+
   .mud-cal-month-header {
     border-right: none;
   }
+}
+
+.mud-cal-week-number {
+  width: 32px;
+  min-width: 32px;
+  flex-shrink: 0;
+  height: 100%;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding-top: 8px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--mud-palette-text-secondary);
+  background-color: var(--mud-palette-background-gray);
+  border-right: 1px solid var(--mud-palette-table-lines);
+  border-top: 1px solid var(--mud-palette-table-lines);
+}
+
+.mud-cal-month-row-content {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  min-width: 0;
+  height: 100%;
 }
 
 .mud-cal-month-layer {


### PR DESCRIPTION
Being a big fan of the Blazor ecosystem I was pleased to find this Calendar component. 
I added some feature that were missing for me, and sharing them in this PR.
Feel free to use / copy / discard.

1. Weeknumbers

Use the `ShowWeekNumbers=true` and a column on the left will show the weeknumbers.

2. Responsive toolbar

- When enabling the PrevNextButtons, they will show on larger screens but autohide on smaller
- The DropDownViewSelector will be used for smaller screens and the buttongroup for larger screens, unless the `ShowDropdownViewSelector=true` than it is always used

3. Monthview scrolling

When there is no fixed height for the cells, the height of the calendar (default 700) is maintained but the calendar scrolls. This gives the advantage that the toolbar remains visible and context of the current month remains visible.

4. Weeksummary

When `MonthWeekSummaryTitle="Hours / week" MonthWeekSummaryTemplate="@(SummaryTemplate)" `

You can add a summary based on the calendarItems of the current week

``` private RenderFragment<CalendarWeekSummary<EmployeeItem>> SummaryTemplate => week =>
        @<text>
            @foreach (var employee in HoursPerEmployee(week))
            {
                <div class="mud-cal-week-summary-row">
                    <span>@employee.Key</span>
                    <span>@employee.Value.ToString("0.#")h</span>
                </div>
            }
        </text>;
 ```
 
 This data will be shown in an added column to the right of the calendar. 
 Context: I use this to help my users who are scheduling 
 
 Best regards
 W.