### PR TITLE
Fix #325: swallow JSDisconnectedException/TaskCanceledException on JSInterop dispose

### DIFF
--- a/Heron.MudCalendar.UnitTests/Components/ResizerTests.cs
+++ b/Heron.MudCalendar.UnitTests/Components/ResizerTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.JSInterop;
+
+namespace Heron.MudCalendar.UnitTests.Components;
+
+public class ResizerTests : BunitTest
+{
+    [Test]
+    public async Task DisposeAsync_DoesNotThrow_WhenCircuitDisconnected()
+    {
+        var moduleInterop = Context.JSInterop.SetupModule("./_content/Heron.MudCalendar/Heron.MudCalendar.min.js");
+        var resizerInterop = moduleInterop.SetupModule("newResizer", _ => true);
+        resizerInterop.SetupVoid("dispose", _ => true).SetException(new JSDisconnectedException("Circuit disconnected."));
+
+        var cut = Context.RenderComponent<Resizer>();
+
+        var act = async () => await cut.Instance.DisposeAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/Heron.MudCalendar.UnitTests/Services/JsServiceTests.cs
+++ b/Heron.MudCalendar.UnitTests/Services/JsServiceTests.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Heron.MudCalendar.Services;
+using Microsoft.JSInterop;
+
+namespace Heron.MudCalendar.UnitTests.Services;
+
+public class JsServiceTests : Components.BunitTest
+{
+    [Test]
+    public async Task DisposeAsync_DoesNotThrow_WhenCircuitDisconnected()
+    {
+        var moduleInterop = Context.JSInterop.SetupModule("./_content/Heron.MudCalendar/Heron.MudCalendar.min.js");
+        var multiSelectInterop = moduleInterop.SetupModule("newMultiSelect", _ => true);
+        multiSelectInterop.SetupVoid("dispose", _ => true).SetException(new JSDisconnectedException("Circuit disconnected."));
+
+        var service = new JsService(Context.JSInterop.JSRuntime);
+        await service.AddMultiSelect(7, "container-id");
+
+        var act = async () => await service.DisposeAsync();
+
+        await act.Should().NotThrowAsync();
+    }
+}

--- a/Heron.MudCalendar/Components/Resizer.razor.cs
+++ b/Heron.MudCalendar/Components/Resizer.razor.cs
@@ -83,8 +83,19 @@ public partial class Resizer : IAsyncDisposable
         if (_this != null) await CastAndDispose(_this);
         if (_resizer != null)
         {
-            await _resizer.InvokeVoidAsync("dispose");
-            await _resizer.DisposeAsync();
+            try
+            {
+                await _resizer.InvokeVoidAsync("dispose");
+                await _resizer.DisposeAsync();
+            }
+            catch (JSDisconnectedException)
+            {
+                // circuit already gone
+            }
+            catch (TaskCanceledException)
+            {
+                // circuit closing
+            }
         }
 
         if (!_moduleTask.IsValueCreated) return;

--- a/Heron.MudCalendar/Services/JsService.cs
+++ b/Heron.MudCalendar/Services/JsService.cs
@@ -105,8 +105,19 @@ public class JsService : IAsyncDisposable
         if (_this != null) await CastAndDispose(_this);
         if (_multiSelect != null)
         {
-            await _multiSelect.InvokeVoidAsync("dispose");
-            await _multiSelect.DisposeAsync();
+            try
+            {
+                await _multiSelect.InvokeVoidAsync("dispose");
+                await _multiSelect.DisposeAsync();
+            }
+            catch (JSDisconnectedException)
+            {
+                // circuit already gone
+            }
+            catch (TaskCanceledException)
+            {
+                // circuit closing
+            }
         }
 
         if (!_moduleTask.IsValueCreated) return;


### PR DESCRIPTION
Addresses https://github.com/danheron/Heron.MudCalendar/issues/325

### Summary

If websocket connection breaks before dispose is called, it currently leads to unhandled exceptions, which don't do anything but are log pollution basically. Microsoft recommends swallowing these exceptions.

> _"In server-side scenarios, always trap JSDisconnectedException in case loss of Blazor's SignalR circuit prevents a JS interop call from disposing a module, which results in an unhandled exception."_